### PR TITLE
docs: input-template — plain value placeholders (drop backticks copied into values)

### DIFF
--- a/examples/input-template.md
+++ b/examples/input-template.md
@@ -16,7 +16,7 @@ Fill out this template to describe the company you want the tool to generate. Th
 
 **Name:** [Display name, e.g., "Newsletter Press" or "Niche Site Empire"]
 
-**Slug:** [Lowercase hyphenated, e.g., `newsletter-press`. This becomes the bundle directory name and the company ID in Paperclip.]
+**Slug:** [Lowercase hyphenated, e.g., newsletter-press. This becomes the bundle directory name and the company ID in Paperclip.]
 
 **One-sentence description:** [The pitch in 20 words or fewer. Used in `COMPANY.md` description, README, and as the company's identifying line in Paperclip's UI.]
 
@@ -163,7 +163,7 @@ If you pick a pattern, the tool uses it as a starting template — suggested age
 - `seo-bureau` — derived from the `seo-bureau` reference. ~15 agents covering technical SEO, content, link acquisition, reporting. For SEO-led service businesses.
 - `custom` — no template; the org_planner designs from scratch.
 
-**Your choice:** [pattern slug, or `custom`]
+**Your choice:** [pattern slug, or custom]
 
 **Notes if customizing the pattern:** [Free text — e.g., "use newsletter but drop the Cross-Promo Lead, we're not running swaps"]
 
@@ -181,7 +181,7 @@ Where on the autonomy ↔ approval spectrum do you want this company to sit? Thi
 - `balanced` — board approves: strategy, hires, budget overrides, custom escalations the agent surfaces. Routine task completion runs autonomously. Suitable for most companies after the first 2-4 weeks.
 - `loose` — board approves: strategy + hires only. Agents have wide latitude on budget and execution. Suitable for operators who have run the company for a quarter+ and trust the agents.
 
-**Your choice:** [`tight` | `balanced` | `loose`]
+**Your choice:** [tight | balanced | loose]
 
 **Notes:** [Free text — e.g., "balanced overall but I want tight approval on anything customer-facing for the first 30 days"]
 


### PR DESCRIPTION
A hand-written brief failed `preview` because scalar values were wrapped in backticks — copied from the template's placeholder styling. The parser keeps the backticks as part of the value, so the slug-regex / use-case-pattern / governance-position validators reject it.

The two example briefs (`indie-game-studio`, `research-digest`) already write these values plain; this brings `examples/input-template.md` in line.

**Changed (value placeholders only):**
- §1 Slug example: `` `newsletter-press` `` → `newsletter-press`
- §7 choice: `` `custom` `` → `custom`
- §8 choice: `` [`tight` | `balanced` | `loose`] `` → `[tight | balanced | loose]`

**Left untouched (descriptive prose):** §7 available-patterns list, §8 spectrum descriptions, §10 default-mapping backticks.

Docs-only, no parser/code change. Independent of branch 010 and the adapter thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)