### PR TITLE
Feature 010: object-model constitution & governance delivery (ADR-022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,18 +12,20 @@ A CLI tool that takes a structured Markdown brief and generates a complete, depl
 
 Give the tool a brief describing a company's identity, north star, goals, and constraints. It produces a directory tree matching Paperclip's import format:
 
-- `.paperclip.yaml` (runtime config: sidebar, agents map, projects map)
+- `.paperclip.yaml` (runtime config: sidebar, per-agent adapter/model/budget, the board-approval company setting, and routines for scheduled work)
 - `COMPANY.md` (Identity, We are, We are not, Constraints, Goals, North star)
 - `README.md` (auto-generated overview with mermaid org chart)
-- `OPERATIONS.md` (phase model, idle-state protocol, approval rules, anti-drift checks)
+- `OPERATIONS.md` (operator-facing operating manual — phase model, idle-state protocol, approval rules, anti-drift; **human docs**, not read by agents)
 - `PROJECT-INVENTORY.md` (starter projects, in-flight + completed tables)
 - `agents/<slug>/` per agent: `AGENTS.md`, `SOUL.md`, `HEARTBEAT.md`, `TOOLS.md`
 - `projects/<slug>/PROJECT.md` per starter project
-- `tasks/<slug>/TASK.md` per starter task
+- `tasks/<slug>/TASK.md` per starter task (a scheduled task is flagged `recurring` and gets a matching routine)
 - `skills/<slug>/SKILL.md` per shared skill
 - `LICENSE.txt`
 
 The result is a Paperclip-importable bundle ready to use.
+
+**How governance reaches agents (ADR-022).** A UI-imported company is database-backed — there is no company-root filesystem for agents to read. So the constitution and rules each agent enforces are folded into its `AGENTS.md` (the carrier the import surfaces to the agent), the board-approval gate ships as a `.paperclip.yaml` company setting, and schedule-driven work becomes routines. `OPERATIONS.md` stays as the operator's readable operating manual, not an agent-facing file.
 
 ## Why this exists
 

--- a/docs/adr/002-output-bundle-format.md
+++ b/docs/adr/002-output-bundle-format.md
@@ -1,8 +1,15 @@
 # ADR-002 — Output Bundle Format
 
-**Status:** Accepted
+**Status:** Accepted (the `OPERATIONS.md` role revised by ADR-022)
 **Date:** Pre-v0.1, during the rework after reference example configs landed
 **Supersedes:** The output specification in the original CLAUDE.md and MASTER_PROMPTS.md (which described a 7-file bundle: `company-spec.md`, `thesis.md`, per-agent SOULs and AGENTS, `ORG.md`, `routines.yml`, `deployment-plan.md`).
+
+> **Revision (ADR-022):** `OPERATIONS.md` is **human/operator documentation only** — it is **not**
+> an agent constitution carrier. A Paperclip import has no "Operations" object, so `OPERATIONS.md`
+> is dropped on import and never reaches running agents. Governance now reaches agents via the
+> per-agent instruction bundle (`AGENTS.md` primary; `SOUL.md` persona anti-drift), routine slots
+> via Routines, and the hiring board-gate via `requireBoardApprovalForNewAgents` in `.paperclip.yaml`.
+> `OPERATIONS.md` stays in the bundle as the operator's readable operating manual. See ADR-022.
 
 ---
 

--- a/docs/adr/022-target-paperclip-object-model-deliver-constitution-to-agents.md
+++ b/docs/adr/022-target-paperclip-object-model-deliver-constitution-to-agents.md
@@ -1,0 +1,165 @@
+# ADR-022: One deployment model (Paperclip object model) — deliver the constitution where agents actually receive it
+
+## Status
+
+Accepted — gate-validated. Drives spec 010 (full spec-kit flow with TDD). Extends ADR-013
+(import fidelity); revises ADR-002 (the role of `OPERATIONS.md`) and reframes the deployment
+model in CLAUDE.md.
+
+## Date
+
+2026-06-26
+
+## Context
+
+A generated bundle imported into a Paperclip company runs **ungoverned** and tells agents to
+read a **company-root filesystem that does not exist**. Verified against the Paperclip
+companies spec, importer source, and a live import (ADR-007). The granular firsthand evidence
+and incident detail are recorded in the local `docs/deployment-gaps.md` (G-P11/G-P12/G-P13);
+this ADR records the decision framed as our own reasoning.
+
+### One deployment model
+
+There is **one** deployment model: a **Paperclip company, database-backed, imported**. "Hermes"
+is **not** a separate whole-company deployment — it is a **per-agent adapter setting**
+(`claude_local` / Hermes / codex, ADR-017) for specific roles. The constitution and governance
+are **always Paperclip-sourced**, regardless of an agent's adapter. There is **no native-Hermes
+whole-company deployment** — the concept is deleted, not demoted to a rare target. So this is
+**object-model-only**; there is no "filesystem mode" to gate behind.
+
+### Storage is split
+
+Agents are **not** filesystem-less. Storage is **split**: **skills materialize as on-disk
+catalog files and are agent-reachable** (an agent can edit a catalog `SKILL.md` and the change
+goes live); **company, operations, projects, issues are database-backed** — there is **no
+company-root tree**. The **only** filesystem an agent may have is its **adapter's own working
+directory** — a code/work `cwd` — referenced **only for code tasks**, never for the
+constitution/governance.
+
+### What is dropped on import
+
+The data model is Company → Projects → Issues → Documents → Comments, plus
+Agents/Goals/Skills/Routines. There is **no "Operations" object**, so `OPERATIONS.md` is
+**dropped entirely**. `COMPANY.md` is only **partially** ingested: name/slug/description
+populate the company record, but "we are"/"we are not", constraints, north star, and **goals**
+are not modeled fields and do **not** survive (goals are not surfaced in the company UI). So the
+governance we work hardest to generate never reaches the running company.
+
+### The carriers that reach agents
+
+The per-agent **instruction bundle is `AGENTS.md` + `SOUL.md` + `HEARTBEAT.md` + `TOOLS.md`** —
+all four reach the agent. `AGENTS.md` is the primary instruction/mandate carrier. Beyond the
+instruction bundle: **Routines** (ingested) carry cadence; **`.paperclip.yaml` company
+settings** carry the one importable governance gate (`requireBoardApprovalForNewAgents`);
+**Skills** (on-disk catalog) inject when relevant; **issue Documents** are an issue-scoped
+backstop. There is **no importable construct** for strategy/spend/custom board reviews or
+per-task review gates (those are runtime approval requests cleared in the UI), and no confirmed
+company-context auto-injection.
+
+### A live incident: operating rules mis-carried in HEARTBEAT, and a faulty idle-state rule
+
+Operating/"critical rules" content was duplicated into each agent's `HEARTBEAT.md` — wrong
+twice: `HEARTBEAT.md` is meant to be the agent's near-empty runtime journal, not a rules
+carrier; and a generated idle-state rule ("leave the issue `in_progress` when a routine is the
+live continuation path") caused a watch agent to spin on a long-lived `in_progress` issue,
+re-waking endlessly (an `in_progress` issue is health-check-demanded constantly, and with
+wake-on-demand the agent re-wakes without end).
+
+## Decision
+
+### 1. Object-model-only — no filesystem deployment mode
+
+Generated companies target the **database-backed Paperclip object model**, the single
+deployment model. Hermes is a **per-agent adapter** setting, not a deployment. `TOOLS.md` is
+**not** made "mode-aware"; the company-root / `COMPANY.md`-as-constitution / `OPERATIONS.md` /
+memory-file assumptions are **removed entirely and unconditionally**.
+
+### 2. Deliver the constitution via the instruction bundle — targeted, distributed
+
+Stop treating `OPERATIONS.md`/`COMPANY.md` *files* as the agents' constitution. Distribute the
+**relevant** content across the four carriers — do **not** duplicate the whole `COMPANY.md`
+into every agent:
+
+- **`AGENTS.md`** carries, per agent: mandate, decision rights, the **idle-state protocol**, and
+  the operating/anti-drift rules that agent must enforce. The **CEO** additionally carries the
+  full board-gate/approval language, the company critical rules, and the company **goals** (which
+  do not survive import).
+- **`SOUL.md`** carries the persona-level "we are not" refusals.
+- **`HEARTBEAT.md`** is the **genuinely-empty** runtime journal at import — no rules, no file
+  references.
+- **Routine slots → Routines** (ingested).
+- **Hiring board-gate → `requireBoardApprovalForNewAgents: true`** in `.paperclip.yaml` (the one
+  importable structured gate). **All other board-gates → CEO `AGENTS.md` prose** (escalate;
+  "ready for Board review"; never self-approve/auto-close) — Paperclip exposes no importable
+  construct for them.
+- **`OPERATIONS.md` stays human/operator documentation only**; the issue-Document operating
+  manual is an optional backstop, never the primary carrier.
+
+### 3. Remove the company-root file-read assumptions; keep only the adapter work-dir, for code
+
+Agents are never told to read the constitution/governance from files. Remove: the `TOOLS.md`
+"File system" section and company-tree line; the `HEARTBEAT.md` file references and duplicated
+rules. The **only** filesystem `TOOLS.md` may reference is the agent's **adapter work `cwd`, for
+code/work tasks only**.
+
+### 4. Correct the idle-state protocol
+
+The generated idle-state protocol MUST state: routine-driven recurring work produces **one
+short-lived issue per scheduled run**, worked and **closed the same run**; an issue is **never**
+left `in_progress` as a liveness marker (the **routine schedule** is the liveness); agents
+produce **zero output** on wakes with nothing to do.
+
+### Scope guard
+
+This realigns *where and to whom* the bundle's content is delivered and corrects one generated
+rule; it does not expand the tool toward a fixed catalogue of templates/presets/roles, and the
+output stays bespoke (same guard as ADR-015/016).
+
+## Consequences
+
+### Positive
+- Governance reaches running agents (instruction bundle) instead of being dropped on import.
+- Agents stop hunting for a non-existent company-root tree, and stop spinning on `in_progress`
+  liveness markers.
+- Output matches the single real deployment path; no manual document re-attachment.
+- Targeted, distributed delivery keeps each carrier lean and `HEARTBEAT.md` empty as intended.
+
+### Negative / limitations
+- The relevant constitution is **duplicated** from `COMPANY.md`/`OPERATIONS.md` into the
+  instruction bundle (and `.paperclip.yaml`/Routines); the generator must keep them in sync.
+- Most board-gates remain prose (only the hiring gate is structurally enforceable on import).
+
+### Neutral
+- `OPERATIONS.md`/`COMPANY.md` remain in the bundle (human docs / company record); their *role*
+  changes, not their presence. Skills remain on-disk catalog files.
+
+## Alternatives considered
+
+- **Mode-aware `TOOLS.md` (filesystem vs objects).** Rejected — one deployment model; Hermes is a
+  per-agent adapter; a mode toggle encodes a conflation.
+- **Keep `OPERATIONS.md`/`COMPANY.md` as the agents' files.** Rejected — dropped/unread on import.
+- **Duplicate the whole `COMPANY.md` into every agent.** Rejected — bloats carriers; targeted
+  per-role delivery suffices.
+- **Carry operating rules in `HEARTBEAT.md`.** Rejected — `HEARTBEAT.md` is the empty runtime
+  journal; carrying rules there caused the spin incident.
+- **Deliver all board-gates structurally.** Not possible — only `requireBoardApprovalForNewAgents`
+  is importable; the rest are runtime approval requests with no manifest field.
+
+## Phase-3 doc edits (greenlit)
+
+- **CLAUDE.md**: state plainly that Hermes is a **per-agent adapter setting** and there is **no
+  native-Hermes whole-company deployment mode**; remove "default deployment = native Hermes".
+- **ADR-002**: revise `OPERATIONS.md`'s role (human/operator docs, not an agent constitution
+  carrier).
+
+## References
+
+- ADR-013 (import fidelity — extended here to COMPANY/OPERATIONS content + the storage model),
+  ADR-002 (revised: OPERATIONS.md role), ADR-007 (source hierarchy), ADR-016 (governance content
+  now delivered via the instruction bundle), ADR-017 (adapters as a per-agent choice — the
+  correct frame for Hermes)
+- Local: `docs/deployment-gaps.md` G-P11 (constitution dropped on import), G-P12 (company-root
+  file-read assumption), G-P13 (operating rules mis-carried in HEARTBEAT + idle-state spin)
+- Spec: `specs/010-object-model-constitution/`
+- Templates touched: `templates/tools_md.j2`, `templates/heartbeat_md.j2`, and the agents/soul/
+  operations generators

--- a/examples/input-template.md
+++ b/examples/input-template.md
@@ -165,7 +165,9 @@ If you pick a pattern, the tool uses it as a starting template — suggested age
 
 **Your choice:** [pattern slug, or custom]
 
-**Notes if customizing the pattern:** [Free text — e.g., "use newsletter but drop the Cross-Promo Lead, we're not running swaps"]
+**These notes are binding.** The org planner treats what you write here as decisive. State an explicit roster (named agents) or a headcount cap and the tool produces exactly that org — it will not add roles or split one role into a sub-team. State which work runs on a **standing schedule** (a cadence like "Mon/Wed/Fri" or "monthly") and those tasks become **recurring** — each yields a routine in `.paperclip.yaml`, and one stated cadence maps to exactly one recurring task. Everything else is handoff- or heartbeat-driven, not a standing schedule.
+
+**Notes if customizing the pattern:** [Free text — e.g., "Exactly four agents: CEO, signal-scanner, opportunity-strategist, senior-analyst; no sub-teams. Only two cadences are scheduled — a Mon/Wed/Fri signal scan and a monthly board package; everything else is handoff/heartbeat-driven."]
 
 ---
 

--- a/examples/input-template.md
+++ b/examples/input-template.md
@@ -16,7 +16,7 @@ Fill out this template to describe the company you want the tool to generate. Th
 
 **Name:** [Display name, e.g., "Newsletter Press" or "Niche Site Empire"]
 
-**Slug:** [Lowercase hyphenated, e.g., `newsletter-press`. This becomes the bundle directory name and the company ID in Paperclip.]
+**Slug:** [Lowercase hyphenated, e.g., newsletter-press. This becomes the bundle directory name and the company ID in Paperclip.]
 
 **One-sentence description:** [The pitch in 20 words or fewer. Used in `COMPANY.md` description, README, and as the company's identifying line in Paperclip's UI.]
 
@@ -163,7 +163,7 @@ If you pick a pattern, the tool uses it as a starting template — suggested age
 - `seo-bureau` — derived from the `seo-bureau` reference. ~15 agents covering technical SEO, content, link acquisition, reporting. For SEO-led service businesses.
 - `custom` — no template; the org_planner designs from scratch.
 
-**Your choice:** [pattern slug, or `custom`]
+**Your choice:** [pattern slug, or custom]
 
 **Notes if customizing the pattern:** [Free text — e.g., "use newsletter but drop the Cross-Promo Lead, we're not running swaps"]
 
@@ -181,7 +181,7 @@ Where on the autonomy ↔ approval spectrum do you want this company to sit? Thi
 - `balanced` — board approves: strategy, hires, budget overrides, custom escalations the agent surfaces. Routine task completion runs autonomously. Suitable for most companies after the first 2-4 weeks.
 - `loose` — board approves: strategy + hires only. Agents have wide latitude on budget and execution. Suitable for operators who have run the company for a quarter+ and trust the agents.
 
-**Your choice:** [`tight` | `balanced` | `loose`]
+**Your choice:** [tight | balanced | loose]
 
 **Notes:** [Free text — e.g., "balanced overall but I want tight approval on anything customer-facing for the first 30 days"]
 

--- a/src/paperclip_blueprints/generators/org.py
+++ b/src/paperclip_blueprints/generators/org.py
@@ -54,6 +54,8 @@ def generate_org_plan(
         governance_position=brief.governance_position,
         single_agent=single_agent,
         seed=seed,
+        free_text=brief.free_text,
+        use_case_notes=brief.use_case_notes,
     )
     payload = client.complete_json(
         model=model or STRUCTURAL_MODEL,

--- a/src/paperclip_blueprints/generators/tasks.py
+++ b/src/paperclip_blueprints/generators/tasks.py
@@ -41,6 +41,7 @@ def generate_task(
             name=stub.name,
             project=stub.project,
             assignee=stub.assignee,
+            recurrence=stub.recurrence,
             **payload,
         )
     except Exception as exc:  # noqa: BLE001

--- a/src/paperclip_blueprints/models/input.py
+++ b/src/paperclip_blueprints/models/input.py
@@ -63,6 +63,10 @@ class CompanyBrief(BaseModel):
     constraints: list[str]
     governance_position: GovernancePosition
     use_case_pattern: str | None = None
+    use_case_notes: str | None = None
+    """Section-7 "Notes if customizing the pattern" prose — the operator's binding
+    org-customization channel (explicit roster, headcount cap, which work is scheduled).
+    Threaded into org_planner so a stated roster/cadence is honored, not expanded past."""
     hours_per_week: int | None = None
     capital_monthly_eur: int | None = None
     capital_setup_eur: int | None = None
@@ -256,6 +260,8 @@ def parse_brief(markdown: str) -> CompanyBrief:
 
     if (v := _inline_value(sec.get(7, ""), "choice")) is not None:
         data["use_case_pattern"] = v
+    if (v := _anchored_block(sec.get(7, ""), "Notes if customizing")) is not None:
+        data["use_case_notes"] = v
     if (v := _inline_value(sec.get(8, ""), "choice")) is not None:
         data["governance_position"] = v
 

--- a/src/paperclip_blueprints/models/org_plan.py
+++ b/src/paperclip_blueprints/models/org_plan.py
@@ -68,6 +68,10 @@ class TaskStub(BaseModel):
     name: str
     project: str
     assignee: str
+    recurrence: str | None = None
+    """Cadence for genuinely schedule-driven standing work, else None (ADR-022, US3). The
+    org_planner sets this — a whole-org structural decision so only the truly scheduled tasks
+    are flagged recurring; threaded into TaskDefinition and keyed off by routine emission."""
 
     @field_validator("slug")
     @classmethod

--- a/src/paperclip_blueprints/models/task.py
+++ b/src/paperclip_blueprints/models/task.py
@@ -14,6 +14,11 @@ class TaskDefinition(BaseModel):
     assignee: str
     objective: str
     completion_criteria: list[str]
+    recurrence: str | None = None
+    """Cadence hint for genuinely schedule-driven standing work (ADR-022, US3): a normalized
+    token (``daily``/``weekly``/``monthly``/``quarterly``) or a comma-separated lowercase
+    weekday list (e.g. ``mon,wed,fri``). ``None`` = not recurring (handoff/heartbeat-driven).
+    Set by org_planner (whole-org structural decision); drives routine emission."""
 
     @field_validator("completion_criteria")
     @classmethod

--- a/src/paperclip_blueprints/prompts/operations_generator.md
+++ b/src/paperclip_blueprints/prompts/operations_generator.md
@@ -42,8 +42,13 @@ drifting away from what it is.
   `critical_rules` as ownership chains: every responsibility has a named primary owner,
   an ordered fallback, and the CEO as the final backstop — nothing is orphaned, and the
   company degrades gracefully when a role is absent.
-- `idle_state_protocol` codifies that idle is a success state: when an agent's queue
-  is empty it proposes work or waits for the next heartbeat rather than inventing it.
+- `idle_state_protocol` codifies idle as a success state AND the correct issue lifecycle for
+  routine-driven work. State explicitly: recurring/routine-driven work runs as ONE short-lived
+  issue per scheduled run, worked and **closed the same run**. **NEVER** leave an issue
+  `in_progress` as a liveness or "continuation" marker — the **routine schedule** is the
+  liveness, not an open issue (a lingering `in_progress` issue is health-check-demanded and
+  re-wakes the agent endlessly). On a wake with nothing to do, the agent produces **zero
+  output** and waits for the next scheduled run rather than inventing work.
 
 ## Output format
 
@@ -52,7 +57,7 @@ Return ONE fenced ```json block and nothing else:
 ```json
 {
   "phase_model": "How the company moves through phases of work.",
-  "idle_state_protocol": "What agents do when idle (idle is a success state).",
+  "idle_state_protocol": "Idle is a success state: one short-lived issue per routine run, closed that run; never leave an issue in_progress as a liveness marker (the schedule is the liveness); zero output on empty wakes.",
   "reporting_cadence": "Who reports what, to whom, how often.",
   "comm_conventions": "How agents communicate and where.",
   "approval_merge_rules": "Approval rules calibrated to governance (plain prose).",

--- a/src/paperclip_blueprints/prompts/org_planner.md
+++ b/src/paperclip_blueprints/prompts/org_planner.md
@@ -26,6 +26,8 @@ single-root tree holds this property: every agent ultimately escalates to the CE
 - North star: {{ north_star }}
 - We are: {{ we_are }}
 {% if governance_position %}- Governance position: {{ governance_position }}{% endif %}
+{% if free_text %}- Operating context: {{ free_text }}{% endif %}
+{% if use_case_notes %}- Customization notes (BINDING — see the roster rule below): {{ use_case_notes }}{% endif %}
 
 {% if single_agent %}
 ## Your task — SINGLE agent
@@ -42,6 +44,12 @@ directly, and NO projects and NO tasks.
 
 Design a complete org for THIS company:
 
+- **Binding customization notes (non-negotiable).** When the customization notes state an
+  explicit roster (named agents), a headcount cap, or which work is scheduled, treat them as
+  BINDING and DECISIVE — they override the sizing guidance below. Produce EXACTLY the stated
+  agents: do NOT add roles beyond the stated roster, do NOT split a stated role into a sub-team
+  or add reports under it, and respect any stated headcount cap. Set each task's `recurrence`
+  ONLY from the cadences the notes state are scheduled, and leave every other task `null`.
 - Exactly ONE root agent (`reports_to: null`) — the owner / CEO-equivalent.
 - Every other agent reports to exactly one existing agent (by slug).
 - **Span of control**: no manager — the CEO included — may have more than 7 direct
@@ -55,6 +63,20 @@ Design a complete org for THIS company:
 - Produce 2–4 starter `projects`, each `owned` by an agent that exists.
 - Produce 4–8 starter `tasks`, each linked to an existing `project` and assigned to an
   existing `assignee` agent.
+- **Recurrence (scheduled work ONLY).** Set a task's `recurrence` to a cadence **only** when
+  the brief states that work runs on a STANDING SCHEDULE (e.g. "every Monday", "Mon/Wed/Fri",
+  "monthly board package"). Otherwise set `recurrence` to `null`. Most tasks are
+  handoff- or heartbeat-driven and MUST be `null` — do NOT flag a task recurring just because
+  it repeats "each cycle"; only genuinely clock-driven standing work gets a cadence. Normalize
+  the cadence to one of `daily`, `weekly`, `monthly`, `quarterly`, or a comma-separated
+  lowercase weekday list (e.g. `mon,wed,fri`). Each recurring task still needs a real
+  `assignee` and `project` — the routine runs as that agent, in that project.
+- **One cadence → one recurring task.** A single stated scheduled cadence maps to EXACTLY ONE
+  recurring task. Do NOT split one scheduled activity into multiple recurring tasks: if that
+  activity has sub-steps (e.g. "scan then log"), fold them into that one recurring task's
+  description, or model the follow-ons as handoff-driven tasks (`recurrence: null`) — never as
+  additional recurring tasks on the same cadence. Genuinely-distinct cadences still get
+  separate recurring tasks (e.g. a `mon,wed,fri` scan and a `monthly` board package are two).
 - `title` and `name` should read like real roles for THIS company.
 {% endif %}
 {% if seed %}
@@ -80,7 +102,7 @@ Return ONE fenced ```json block and nothing else, matching this shape exactly:
     {"slug": "project-slug", "name": "Readable Project Name", "owner": "an-agent-slug"}
   ],
   "tasks": [
-    {"slug": "task-slug", "name": "Readable Task Name", "project": "project-slug", "assignee": "an-agent-slug"}
+    {"slug": "task-slug", "name": "Readable Task Name", "project": "project-slug", "assignee": "an-agent-slug", "recurrence": null}
   ]
 }
 ```

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -22,7 +22,7 @@ from ..models.task import TaskDefinition
 from .adapter import assign_adapters
 from .budget import allocate_budgets
 from .frontmatter import dump_frontmatter
-from .routines import derive_routines, routine_task_files
+from .routines import RoutineSpec, derive_routines
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
@@ -107,15 +107,18 @@ def _project_frontmatter(project: ProjectDefinition) -> str:
 
 
 def _task_frontmatter(task: TaskDefinition) -> str:
-    return dump_frontmatter(
-        {
-            "schema": "agentcompanies/v1",
-            "slug": task.slug,
-            "name": task.name,
-            "project": task.project,
-            "assignee": task.assignee,
-        }
-    )
+    fields: dict[str, object] = {
+        "schema": "agentcompanies/v1",
+        "slug": task.slug,
+        "name": task.name,
+        "project": task.project,
+        "assignee": task.assignee,
+    }
+    # A scheduled task is flagged recurring (ADR-022 US3); its schedule rides `.paperclip.yaml`
+    # routines.<slug>. One task set — recurring ones are flagged, never duplicated.
+    if task.recurrence:
+        fields["recurring"] = True
+    return dump_frontmatter(fields)
 
 
 def _role_bucket(agent: AgentDefinition, is_manager: bool) -> str:
@@ -130,6 +133,26 @@ def _role_bucket(agent: AgentDefinition, is_manager: bool) -> str:
     ):
         return "engineering"
     return "generic"
+
+
+def _routine_cadence_smells(routines: list[RoutineSpec]) -> list[str]:
+    """Soft smell-detector (ADR-022 US3): two recurring tasks on the SAME cadence AND assignee
+    are likely one scheduled activity split into two (the org_planner one-cadence rule).
+
+    Advisory only — surfaced via the ``warn`` sink, NEVER a validation error: a genuinely
+    doubled cadence on one owner is legitimate, so the operator judges. Grouped by
+    ``(cron, assignee)`` (not cron alone — two owners can share a cadence without a smell).
+    """
+    groups: dict[tuple[str, str], list[str]] = {}
+    for r in routines:
+        groups.setdefault((r.cron, r.assignee), []).append(r.slug)
+    return [
+        f"routines {sorted(slugs)} share cadence {cron!r} and assignee {assignee!r} — likely one "
+        "scheduled activity split into multiple recurring tasks; consider folding into one "
+        "recurring task (org_planner one-cadence rule)"
+        for (cron, assignee), slugs in groups.items()
+        if len(slugs) > 1
+    ]
 
 
 def render_files(
@@ -160,17 +183,13 @@ def render_files(
     # from the same role buckets, emitted under each agent's `adapter`. Never `env`.
     adapters = assign_adapters(role_by_slug)
 
-    # Routine slots → importable Routines (ADR-022, US3, PROVISIONAL): a `.paperclip.yaml`
-    # routines block + a recurring TASK.md per routine. Empty without operations or a project.
-    routines = (
-        derive_routines(
-            config.operations.routine_slots,
-            {a.slug for a in config.agents},
-            [p.slug for p in config.projects],
-        )
-        if config.operations is not None
-        else []
-    )
+    # Tasks with a `recurrence` cadence → importable Routines (ADR-022, US3, PROVISIONAL cron):
+    # a `.paperclip.yaml` routines.<task-slug> block; the recurring task itself is flagged
+    # `recurring: true` (no shadow task). Empty when no task is scheduled.
+    routines = derive_routines(config.tasks)
+    if warn is not None:
+        for message in _routine_cadence_smells(routines):
+            warn(message)
 
     base = {
         "brief": config.brief,
@@ -243,9 +262,5 @@ def render_files(
         files[f"tasks/{task.slug}/TASK.md"] = (
             _task_frontmatter(task) + "\n" + _render("task_md.j2", task=task)
         )
-
-    # Recurring TASK.md files for the routines (the task half; the schedule lives in
-    # `.paperclip.yaml routines.<slug>`). ADR-022 US3, PROVISIONAL.
-    files.update(routine_task_files(routines))
 
     return files

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -188,13 +188,24 @@ def render_files(
         files["PROJECT-INVENTORY.md"] = _render(
             "project_inventory_md.j2", company=config.company, projects=config.projects
         )
+    # Governance reaches agents via the instruction bundle, not OPERATIONS.md/COMPANY.md files
+    # (ADR-022): every AGENTS.md carries the idle-state protocol; the CEO/root additionally
+    # carries the company goals (which do not survive import), the board-gate/approval language,
+    # and the company critical rules. Targeted per role — not the whole manual.
+    ops = config.operations
     for agent in config.agents:
+        is_root = agent.reports_to is None
         actx = {
             "brief": config.brief,
             "company": config.company,
             "agent": agent,
             "soul": agent.soul,
             "role_bucket": _role_bucket(agent, agent.slug in manager_slugs),
+            "is_root": is_root,
+            "idle_state_protocol": ops.idle_state_protocol if ops is not None else None,
+            "company_goals": config.company.goals if is_root else [],
+            "critical_rules": ops.critical_rules if (is_root and ops is not None) else [],
+            "board_gate": ops.approval_merge_rules if (is_root and ops is not None) else None,
         }
         adir = f"agents/{agent.slug}"
         files[f"{adir}/AGENTS.md"] = (

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -22,6 +22,7 @@ from ..models.task import TaskDefinition
 from .adapter import assign_adapters
 from .budget import allocate_budgets
 from .frontmatter import dump_frontmatter
+from .routines import derive_routines, routine_task_files
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
@@ -159,6 +160,18 @@ def render_files(
     # from the same role buckets, emitted under each agent's `adapter`. Never `env`.
     adapters = assign_adapters(role_by_slug)
 
+    # Routine slots → importable Routines (ADR-022, US3, PROVISIONAL): a `.paperclip.yaml`
+    # routines block + a recurring TASK.md per routine. Empty without operations or a project.
+    routines = (
+        derive_routines(
+            config.operations.routine_slots,
+            {a.slug for a in config.agents},
+            [p.slug for p in config.projects],
+        )
+        if config.operations is not None
+        else []
+    )
+
     base = {
         "brief": config.brief,
         "company": config.company,
@@ -169,6 +182,7 @@ def render_files(
         "license_kind": config.license_kind,
         "budgets": allocation.cents,
         "adapters": adapters,
+        "routines": routines,
     }
 
     files: dict[str, str] = {
@@ -229,5 +243,9 @@ def render_files(
         files[f"tasks/{task.slug}/TASK.md"] = (
             _task_frontmatter(task) + "\n" + _render("task_md.j2", task=task)
         )
+
+    # Recurring TASK.md files for the routines (the task half; the schedule lives in
+    # `.paperclip.yaml routines.<slug>`). ADR-022 US3, PROVISIONAL.
+    files.update(routine_task_files(routines))
 
     return files

--- a/src/paperclip_blueprints/renderers/routines.py
+++ b/src/paperclip_blueprints/renderers/routines.py
@@ -1,0 +1,120 @@
+"""Routine emission (ADR-022, US3) — PROVISIONAL, pending live-import confirmation.
+
+Converts coarse routine slots ("agent-slug: cadence …") into importable Paperclip Routines.
+A routine is two coordinated pieces (Paperclip importer source, ADR-007 tier-3):
+
+1. a **recurring task** — ``tasks/<slug>/TASK.md`` with ``recurring: true`` + ``assignee`` +
+   ``project`` (the project is MANDATORY; the importer rejects a routine without one);
+2. a top-level ``.paperclip.yaml`` ``routines.<task-slug>`` block with a ``schedule`` trigger
+   (``cronExpression`` + ``timezone``) and concurrency/catch-up policies (defaults
+   ``coalesce_if_active`` / ``skip_missed``).
+
+**PROVISIONAL** — the live import is the acceptance gate for: the ``routines.<slug>`` key
+matching the recurring task's slug, cron validity, and assignee/project resolution. Kept in this
+one module on purpose so a live correction is a contained, single-file change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from ..paperclip_slug import slugify_project_name
+from .frontmatter import dump_frontmatter
+
+# Provisional cron map: a coarse cadence keyword -> a 09:00 cron. The live import confirms cron
+# validity; these are sensible defaults, not operator-authored schedules.
+_CRON = {
+    "daily": "0 9 * * *",
+    "weekly": "0 9 * * 1",
+    "biweekly": "0 9 * * 1",
+    "monthly": "0 9 1 * *",
+    "quarterly": "0 9 1 1,4,7,10 *",
+    "yearly": "0 9 1 1 *",
+    "annual": "0 9 1 1 *",
+}
+_DEFAULT_CRON = "0 9 * * 1"  # weekly fallback
+
+
+@dataclass(frozen=True)
+class RoutineSpec:
+    """One routine: the recurring-task fields plus the ``.paperclip.yaml`` schedule trigger."""
+
+    slug: str
+    name: str
+    assignee: str
+    project: str
+    cron: str
+    timezone: str = "UTC"
+    concurrency_policy: str = "coalesce_if_active"
+    catch_up_policy: str = "skip_missed"
+    description: str = ""
+
+
+def _cron_for(cadence: str) -> str:
+    low = cadence.lower()
+    for key, cron in _CRON.items():
+        if key in low:
+            return cron
+    return _DEFAULT_CRON
+
+
+def derive_routines(
+    routine_slots: Sequence[str], agent_slugs: set[str], project_slugs: Sequence[str]
+) -> list[RoutineSpec]:
+    """Map ``routine_slots`` ("agent-slug: cadence") to RoutineSpecs (PROVISIONAL).
+
+    Returns ``[]`` when there is no project to anchor a routine (the importer requires one) or no
+    recognizable agent. The project anchor is provisional — the first project — and the cron is
+    derived from a coarse cadence keyword; both are exactly what a live import confirms.
+    """
+    if not project_slugs:
+        return []
+    project = project_slugs[0]
+    specs: list[RoutineSpec] = []
+    seen: set[str] = set()
+    for slot in routine_slots:
+        agent, sep, cadence = slot.partition(":")
+        agent = agent.strip()
+        cadence = (cadence.strip() if sep else "") or slot.strip()
+        if agent not in agent_slugs:
+            continue
+        base = slugify_project_name(f"{agent}-{cadence}") or f"{agent}-routine"
+        slug, n = base, 2
+        while slug in seen:
+            slug, n = f"{base}-{n}", n + 1
+        seen.add(slug)
+        specs.append(
+            RoutineSpec(
+                slug=slug,
+                name=cadence[:80] or "Routine",
+                assignee=agent,
+                project=project,
+                cron=_cron_for(cadence),
+                description=f"Routine: {cadence}",
+            )
+        )
+    return specs
+
+
+def routine_task_files(routines: Sequence[RoutineSpec]) -> dict[str, str]:
+    """The recurring ``TASK.md`` files (the task half of each routine)."""
+    files: dict[str, str] = {}
+    for r in routines:
+        frontmatter = dump_frontmatter(
+            {
+                "schema": "agentcompanies/v1",
+                "slug": r.slug,
+                "name": r.name,
+                "project": r.project,
+                "assignee": r.assignee,
+                "recurring": True,
+            }
+        )
+        body = (
+            f"# {r.name}\n\n{r.description}\n\n"
+            f"This is a recurring (routine) task; its schedule lives in `.paperclip.yaml` "
+            f"under `routines.{r.slug}`.\n"
+        )
+        files[f"tasks/{r.slug}/TASK.md"] = frontmatter + "\n" + body
+    return files

--- a/src/paperclip_blueprints/renderers/routines.py
+++ b/src/paperclip_blueprints/renderers/routines.py
@@ -1,30 +1,32 @@
-"""Routine emission (ADR-022, US3) — PROVISIONAL, pending live-import confirmation.
+"""Routine emission (ADR-022, US3) — PROVISIONAL cron, pending live-import confirmation.
 
-Converts coarse routine slots ("agent-slug: cadence …") into importable Paperclip Routines.
-A routine is two coordinated pieces (Paperclip importer source, ADR-007 tier-3):
+Routines are driven by the **tasks**: a task carries a ``recurrence`` cadence (set by org_planner
+for genuinely schedule-driven standing work, else ``None``). Each recurring task becomes a
+Paperclip Routine — two coordinated pieces:
 
-1. a **recurring task** — ``tasks/<slug>/TASK.md`` with ``recurring: true`` + ``assignee`` +
-   ``project`` (the project is MANDATORY; the importer rejects a routine without one);
+1. the **existing** ``tasks/<slug>/TASK.md`` is flagged ``recurring: true`` (it keeps its real
+   ``assignee`` + ``project`` — the routine runs as that agent, in that project; the importer
+   requires the project). There is **no** separate "routine task": one task set, recurring ones
+   flagged.
 2. a top-level ``.paperclip.yaml`` ``routines.<task-slug>`` block with a ``schedule`` trigger
    (``cronExpression`` + ``timezone``) and concurrency/catch-up policies (defaults
    ``coalesce_if_active`` / ``skip_missed``).
 
-**PROVISIONAL** — the live import is the acceptance gate for: the ``routines.<slug>`` key
-matching the recurring task's slug, cron validity, and assignee/project resolution. Kept in this
-one module on purpose so a live correction is a contained, single-file change.
+The cadence→cron translation honors the brief's stated cadence (``mon,wed,fri`` → ``0 9 * * 1,3,5``,
+``monthly`` → ``0 9 1 * *``). The cron string and the ``routines.<slug>`` shape stay **PROVISIONAL**
+— confirmed only at live import. Kept in this one module so a live correction is contained.
 """
 
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 
-from ..paperclip_slug import slugify_project_name
-from .frontmatter import dump_frontmatter
+from ..models.task import TaskDefinition
 
-# Provisional cron map: a coarse cadence keyword -> a 09:00 cron. The live import confirms cron
-# validity; these are sensible defaults, not operator-authored schedules.
-_CRON = {
+# Named cadence -> 09:00 cron (provisional defaults; live import confirms cron validity).
+_NAMED_CRON = {
     "daily": "0 9 * * *",
     "weekly": "0 9 * * 1",
     "biweekly": "0 9 * * 1",
@@ -33,14 +35,18 @@ _CRON = {
     "yearly": "0 9 1 1 *",
     "annual": "0 9 1 1 *",
 }
-_DEFAULT_CRON = "0 9 * * 1"  # weekly fallback
+_DEFAULT_CRON = "0 9 * * 1"  # weekly fallback for an unrecognized cadence
+
+# Weekday token -> cron day-of-week (Sun=0 … Sat=6). Keyed on the 3-letter prefix so both
+# "mon" and "monday" resolve.
+_DOW = {"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6}
 
 
 @dataclass(frozen=True)
 class RoutineSpec:
-    """One routine: the recurring-task fields plus the ``.paperclip.yaml`` schedule trigger."""
+    """One routine: the recurring task's identity + its ``.paperclip.yaml`` schedule trigger."""
 
-    slug: str
+    slug: str  # == the recurring task's slug (short, stable)
     name: str
     assignee: str
     project: str
@@ -48,73 +54,39 @@ class RoutineSpec:
     timezone: str = "UTC"
     concurrency_policy: str = "coalesce_if_active"
     catch_up_policy: str = "skip_missed"
-    description: str = ""
 
 
-def _cron_for(cadence: str) -> str:
-    low = cadence.lower()
-    for key, cron in _CRON.items():
-        if key in low:
-            return cron
+def cron_for(cadence: str) -> str:
+    """Translate a cadence hint to a cron expression (PROVISIONAL — live import confirms validity).
+
+    Handles the named cadences (daily/weekly/monthly/quarterly/…) and a weekday list
+    (``mon,wed,fri`` / ``monday wednesday friday`` → ``0 9 * * 1,3,5``). Unrecognized → weekly.
+    """
+    c = cadence.strip().lower()
+    if c in _NAMED_CRON:
+        return _NAMED_CRON[c]
+    days = sorted({_DOW[tok[:3]] for tok in re.split(r"[^a-z]+", c) if tok[:3] in _DOW})
+    if days:
+        return f"0 9 * * {','.join(str(d) for d in days)}"
     return _DEFAULT_CRON
 
 
-def derive_routines(
-    routine_slots: Sequence[str], agent_slugs: set[str], project_slugs: Sequence[str]
-) -> list[RoutineSpec]:
-    """Map ``routine_slots`` ("agent-slug: cadence") to RoutineSpecs (PROVISIONAL).
+def derive_routines(tasks: Sequence[TaskDefinition]) -> list[RoutineSpec]:
+    """Build a RoutineSpec for each task that carries a ``recurrence`` cadence.
 
-    Returns ``[]`` when there is no project to anchor a routine (the importer requires one) or no
-    recognizable agent. The project anchor is provisional — the first project — and the cron is
-    derived from a coarse cadence keyword; both are exactly what a live import confirms.
+    Routines are keyed off the real task slug (short, stable) and inherit the task's own
+    ``assignee`` + ``project`` (so each routine resolves to a real agent and project on import).
+    Non-recurring tasks contribute nothing — this is what keeps emission to the genuinely
+    scheduled work.
     """
-    if not project_slugs:
-        return []
-    project = project_slugs[0]
-    specs: list[RoutineSpec] = []
-    seen: set[str] = set()
-    for slot in routine_slots:
-        agent, sep, cadence = slot.partition(":")
-        agent = agent.strip()
-        cadence = (cadence.strip() if sep else "") or slot.strip()
-        if agent not in agent_slugs:
-            continue
-        base = slugify_project_name(f"{agent}-{cadence}") or f"{agent}-routine"
-        slug, n = base, 2
-        while slug in seen:
-            slug, n = f"{base}-{n}", n + 1
-        seen.add(slug)
-        specs.append(
-            RoutineSpec(
-                slug=slug,
-                name=cadence[:80] or "Routine",
-                assignee=agent,
-                project=project,
-                cron=_cron_for(cadence),
-                description=f"Routine: {cadence}",
-            )
+    return [
+        RoutineSpec(
+            slug=t.slug,
+            name=t.name,
+            assignee=t.assignee,
+            project=t.project,
+            cron=cron_for(t.recurrence),
         )
-    return specs
-
-
-def routine_task_files(routines: Sequence[RoutineSpec]) -> dict[str, str]:
-    """The recurring ``TASK.md`` files (the task half of each routine)."""
-    files: dict[str, str] = {}
-    for r in routines:
-        frontmatter = dump_frontmatter(
-            {
-                "schema": "agentcompanies/v1",
-                "slug": r.slug,
-                "name": r.name,
-                "project": r.project,
-                "assignee": r.assignee,
-                "recurring": True,
-            }
-        )
-        body = (
-            f"# {r.name}\n\n{r.description}\n\n"
-            f"This is a recurring (routine) task; its schedule lives in `.paperclip.yaml` "
-            f"under `routines.{r.slug}`.\n"
-        )
-        files[f"tasks/{r.slug}/TASK.md"] = frontmatter + "\n" + body
-    return files
+        for t in tasks
+        if t.recurrence
+    ]

--- a/src/paperclip_blueprints/templates/agents_md.j2
+++ b/src/paperclip_blueprints/templates/agents_md.j2
@@ -47,3 +47,33 @@
 ## Escalation
 
 {{ agent.escalation_text }}
+
+## Idle-state protocol
+
+{% if idle_state_protocol %}
+{{ idle_state_protocol }}
+{% else %}
+Idle is a success state. Between scheduled triggers I wait; I do not invent work to look busy, and I never leave an issue `in_progress` as a liveness marker — the schedule is the liveness.
+{% endif %}
+{% if is_root %}
+
+## Company goals
+
+{% for g in company_goals %}
+- {{ g }}
+{% endfor %}
+{% if board_gate %}
+
+## Board-gate and approval
+
+{{ board_gate }}
+{% endif %}
+{% if critical_rules %}
+
+## Critical rules
+
+{% for c in critical_rules %}
+- {{ c }}
+{% endfor %}
+{% endif %}
+{% endif %}

--- a/src/paperclip_blueprints/templates/heartbeat_md.j2
+++ b/src/paperclip_blueprints/templates/heartbeat_md.j2
@@ -20,8 +20,7 @@ Over time, this file becomes your personal heartbeat procedure — the steps you
 **Do not** use this file for:
 - Role identity → that's `SOUL.md`.
 - Tool references → that's `TOOLS.md`.
-- Company rules → that's `OPERATIONS.md` and `COMPANY.md`.
-- Daily activity notes → that's `memory/<date>.md` via the `para-memory-files` skill.
+- Your mandate, decision rights, idle-state protocol, and operating rules → those are in `AGENTS.md`.
 
 ---
 
@@ -37,6 +36,6 @@ Over time, this file becomes your personal heartbeat procedure — the steps you
 
 ---
 
-## Critical rules summary
+## Notes to self
 
-*(Empty — echo the most-load-bearing rules from `OPERATIONS.md` and your own `SOUL.md` here once you have a stable wakeup flow.)*
+*(Empty — jot any load-bearing rule you rediscover during real wakeups here. Your authoritative rules live in `AGENTS.md`.)*

--- a/src/paperclip_blueprints/templates/paperclip_yaml.j2
+++ b/src/paperclip_blueprints/templates/paperclip_yaml.j2
@@ -1,4 +1,6 @@
 schema: paperclip/v1
+company:
+  requireBoardApprovalForNewAgents: true
 sidebar:
   agents: [{{ agents | map(attribute='slug') | join(', ') }}]
   projects: [{{ projects | map(attribute='slug') | join(', ') }}]
@@ -25,4 +27,19 @@ projects:
 {% endfor %}
 {% else %}
 projects: {}
+{% endif %}
+{% if routines %}
+# Routines (ADR-022, PROVISIONAL — shape derived from the Paperclip importer source; the live
+# import is the acceptance check for the routines.<task-slug> key match, cron validity, and the
+# assignee/project resolution). Keyed by the recurring task's slug.
+routines:
+{% for r in routines %}
+  {{ r.slug }}:
+    concurrencyPolicy: {{ r.concurrency_policy }}
+    catchUpPolicy: {{ r.catch_up_policy }}
+    triggers:
+      - kind: schedule
+        cronExpression: "{{ r.cron }}"
+        timezone: {{ r.timezone }}
+{% endfor %}
 {% endif %}

--- a/src/paperclip_blueprints/templates/tools_md.j2
+++ b/src/paperclip_blueprints/templates/tools_md.j2
@@ -8,14 +8,6 @@ Load the **`paperclip` skill** for any Paperclip API interaction. It covers the 
 - Agent ID: `<set at runtime>`
 - Company ID: `$PAPERCLIP_COMPANY_ID`
 
-## File system
-
-- Company root: `{{ brief.slug }}/` (relative to import location)
-- Agent home: `agents/{{ agent.slug }}/`
-- Company constitution: `COMPANY.md`
-- Own memory: `agents/{{ agent.slug }}/memory/` (daily notes — the `para-memory-files` skill manages this)
-- Own runtime journal: `agents/{{ agent.slug }}/HEARTBEAT.md`
-
 ## Role-specific tools
 
 {{ agent.tools_role_specific }}
@@ -35,5 +27,5 @@ Load the **`paperclip` skill** for any Paperclip API interaction. It covers the 
 - I keep my work inside my mandate and hand off cleanly, with the deliverable in its agreed location.
 - I escalate rather than guess when a decision is outside my decision rights.
 {% endif %}
-- I never paste secrets, credentials, or pricing experiments into agent comments — these live in the relevant folder under the company tree.
+- I never paste secrets, credentials, or pricing experiments into agent comments.
 - Any secret is referenced via an environment variable or an external secret file, never baked into a file in this bundle.

--- a/src/paperclip_blueprints/validators/integrity.py
+++ b/src/paperclip_blueprints/validators/integrity.py
@@ -39,6 +39,17 @@ def _expected_files(config: CompanyConfig) -> set[str]:
         files.add(f"projects/{p.slug}/PROJECT.md")
     for t in config.tasks:
         files.add(f"tasks/{t.slug}/TASK.md")
+    # Recurring TASK.md files generated for routines (ADR-022 US3); derived deterministically
+    # from the same operations.routine_slots the renderer uses, so I10 expects exactly them.
+    if config.operations is not None:
+        from ..renderers.routines import derive_routines
+
+        for r in derive_routines(
+            config.operations.routine_slots,
+            {a.slug for a in config.agents},
+            [p.slug for p in config.projects],
+        ):
+            files.add(f"tasks/{r.slug}/TASK.md")
     return files
 
 

--- a/src/paperclip_blueprints/validators/integrity.py
+++ b/src/paperclip_blueprints/validators/integrity.py
@@ -39,17 +39,8 @@ def _expected_files(config: CompanyConfig) -> set[str]:
         files.add(f"projects/{p.slug}/PROJECT.md")
     for t in config.tasks:
         files.add(f"tasks/{t.slug}/TASK.md")
-    # Recurring TASK.md files generated for routines (ADR-022 US3); derived deterministically
-    # from the same operations.routine_slots the renderer uses, so I10 expects exactly them.
-    if config.operations is not None:
-        from ..renderers.routines import derive_routines
-
-        for r in derive_routines(
-            config.operations.routine_slots,
-            {a.slug for a in config.agents},
-            [p.slug for p in config.projects],
-        ):
-            files.add(f"tasks/{r.slug}/TASK.md")
+    # Routines (ADR-022 US3) add NO files: a recurring task is the existing task flagged
+    # `recurring: true`, not a separate shadow task — so the expected set is unchanged.
     return files
 
 

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -161,11 +161,12 @@ def check_schema_shape(config: CompanyConfig, files: dict[str, str]) -> list[str
         if rel.endswith("SOUL.md") and "idle" not in text.lower():
             v.append(f"S6: {rel} must include an idle-state belief")
 
-    # S7 + S8 + S11: full-bundle-only checks.
+    # S7 + S8 + S11 + V-gov: full-bundle-only checks.
     if config.operations is not None:
         v += _check_operations(config, files.get("OPERATIONS.md", ""))
         v += _check_inventory(config, files.get("PROJECT-INVENTORY.md", ""))
         v += _check_board_authority(files.get("OPERATIONS.md", ""))
+        v += _check_governance_delivery(config, files)
 
     # S9: body-only files carry no schema frontmatter.
     for rel, text in files.items():
@@ -271,6 +272,31 @@ def _check_operations(config: CompanyConfig, ops: str) -> list[str]:
         if terms and not any(t in haystack for t in terms):
             v.append(f"S7: OPERATIONS.md anti-drift checks do not cover {item!r}")
     v += _check_idle_state(config.operations.idle_state_protocol)
+    return v
+
+
+def _check_governance_delivery(config: CompanyConfig, files: dict[str, str]) -> list[str]:
+    """V-gov (ADR-022): governance reaches agents via the instruction bundle.
+
+    Every agent's ``AGENTS.md`` carries the idle-state protocol; the CEO/root additionally
+    carries the company goals, the board-gate/approval language, and the company critical rules.
+    (Full bundles only — gated by the caller on ``config.operations``.)
+    """
+    v: list[str] = []
+    for a in config.agents:
+        am = files.get(f"agents/{a.slug}/AGENTS.md", "")
+        if "## Idle-state protocol" not in am:
+            v.append(
+                f"V-gov: agents/{a.slug}/AGENTS.md is missing the idle-state protocol (ADR-022)"
+            )
+    for r in (a for a in config.agents if a.reports_to is None):
+        am = files.get(f"agents/{r.slug}/AGENTS.md", "")
+        for section in ("## Company goals", "## Board-gate and approval", "## Critical rules"):
+            if section not in am:
+                v.append(
+                    f"V-gov: CEO agents/{r.slug}/AGENTS.md is missing section {section!r} "
+                    "(governance must reach the CEO via AGENTS.md, not OPERATIONS.md — ADR-022)"
+                )
     return v
 
 

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -17,6 +17,11 @@ from ..models.output import CompanyConfig
 _BODY_ONLY_SUFFIXES = ("SOUL.md", "HEARTBEAT.md", "TOOLS.md")
 _BODY_ONLY_TOP = ("README.md", "OPERATIONS.md", "PROJECT-INVENTORY.md", "LICENSE.txt")
 
+# S13 (ADR-022): filesystem-read markers an agent file must never carry — a UI-imported
+# company is database-backed with no company-root tree, so the constitution/governance must
+# reach agents via the instruction bundle, never as files.
+_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>", "para-memory-files")
+
 _OPERATIONS_HEADINGS = (
     "## Phase model",
     "## Idle-state protocol",
@@ -168,6 +173,17 @@ def check_schema_shape(config: CompanyConfig, files: dict[str, str]) -> list[str
             if "schema: agentcompanies/v1" in text or "schema: paperclip/v1" in text:
                 v.append(f"S9: body-only file {rel} must not carry a schema frontmatter")
 
+    # S13 (ADR-022): agent files must not instruct reading the constitution/governance from a
+    # filesystem path — a UI-imported company is DB-backed with no company-root tree.
+    for rel, text in files.items():
+        if rel.endswith(("AGENTS.md", "SOUL.md", "HEARTBEAT.md", "TOOLS.md")):
+            for marker in _FS_MARKERS:
+                if marker in text:
+                    v.append(
+                        f"S13: {rel} instructs a filesystem read ({marker!r}); the import "
+                        "provides no company-root filesystem (ADR-022)"
+                    )
+
     return v
 
 
@@ -254,7 +270,40 @@ def _check_operations(config: CompanyConfig, ops: str) -> list[str]:
         terms = _key_terms(item)
         if terms and not any(t in haystack for t in terms):
             v.append(f"S7: OPERATIONS.md anti-drift checks do not cover {item!r}")
+    v += _check_idle_state(config.operations.idle_state_protocol)
     return v
+
+
+def _check_idle_state(protocol: str) -> list[str]:
+    """V-idle (ADR-022): the idle-state protocol must not leave an issue ``in_progress`` as a
+    liveness/continuation marker — the routine schedule is the liveness.
+
+    Sentence-level negation check: a sentence mentioning ``in_progress`` together with a
+    leave/keep/liveness/continuation cue is a violation UNLESS negated (the correct protocol
+    says "never leave an issue in_progress as a liveness marker", which is negated and passes).
+    A lingering ``in_progress`` issue is health-check-demanded and re-wakes the agent endlessly.
+    """
+    text = protocol.lower()
+    cues = ("leave", "keep", "liveness", "continuation", "alive", "stay open", "kept open")
+    negations = (
+        "never",
+        "not ",
+        "n't",
+        "rather than",
+        "instead of",
+        "avoid",
+        "without",
+        "no longer",
+    )
+    for sentence in re.split(r"[.\n;]", text):
+        if not any(s in sentence for s in ("in_progress", "in progress", "inprogress")):
+            continue
+        if any(c in sentence for c in cues) and not any(n in sentence for n in negations):
+            return [
+                "V-idle: idle-state protocol must not leave an issue in_progress as a "
+                "liveness/continuation marker (the routine schedule is the liveness) — ADR-022"
+            ]
+    return []
 
 
 def _check_inventory(config: CompanyConfig, inv: str) -> list[str]:

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -122,6 +122,12 @@ def check_schema_shape(config: CompanyConfig, files: dict[str, str]) -> list[str
     # credentials stay operator-environment).
     v += _check_adapter_fields(files.get(".paperclip.yaml", ""))
 
+    # S14 (ADR-022): the hiring board-gate ships as a structured, importable company setting.
+    if "requireBoardApprovalForNewAgents: true" not in files.get(".paperclip.yaml", ""):
+        v.append(
+            "S14: .paperclip.yaml must set company.requireBoardApprovalForNewAgents: true (ADR-022)"
+        )
+
     # S2: agentcompanies/v1 on every content file.
     for rel, text in files.items():
         if rel == "COMPANY.md" or rel.endswith(("AGENTS.md", "SKILL.md", "PROJECT.md", "TASK.md")):

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -128,6 +128,10 @@ def check_schema_shape(config: CompanyConfig, files: dict[str, str]) -> list[str
             "S14: .paperclip.yaml must set company.requireBoardApprovalForNewAgents: true (ADR-022)"
         )
 
+    # S15 (ADR-022): routines.<slug> blocks ⇔ tasks flagged `recurring: true` (one task set;
+    # no shadow routine tasks, no orphan routine blocks).
+    v += _check_routines_closure(files)
+
     # S2: agentcompanies/v1 on every content file.
     for rel, text in files.items():
         if rel == "COMPANY.md" or rel.endswith(("AGENTS.md", "SKILL.md", "PROJECT.md", "TASK.md")):
@@ -209,6 +213,34 @@ def _check_board_authority(ops: str) -> list[str]:
         "board-gated decisions and that agents escalate (ready for Board review) "
         "rather than self-approving"
     ]
+
+
+def _check_routines_closure(files: dict[str, str]) -> list[str]:
+    """S15 (ADR-022): every ``.paperclip.yaml`` ``routines.<slug>`` key matches a task whose
+    ``TASK.md`` is flagged ``recurring: true``, and vice versa.
+
+    Guards the routines↔task invariant: routines are emitted only from recurring tasks (no
+    over-generation), keyed off the real task slug (no shadow tasks, no orphan routine blocks).
+    """
+    yaml_text = files.get(".paperclip.yaml", "")
+    try:
+        data = YAML(typ="safe").load(yaml_text) or {}
+    except Exception:  # noqa: BLE001 - I9 reports unparseable YAML; don't double-fault
+        return []
+    routine_keys = set((data.get("routines") or {}).keys())
+    recurring_tasks = {
+        rel.split("/")[1]
+        for rel, text in files.items()
+        if rel.startswith("tasks/")
+        and rel.endswith("/TASK.md")
+        and re.search(r"^recurring:\s*true\b", text, re.MULTILINE | re.IGNORECASE)
+    }
+    v: list[str] = []
+    for missing in sorted(recurring_tasks - routine_keys):
+        v.append(f"S15: recurring task {missing!r} has no .paperclip.yaml routines.<slug> block")
+    for orphan in sorted(routine_keys - recurring_tasks):
+        v.append(f"S15: routines.{orphan} has no matching task flagged 'recurring: true'")
+    return v
 
 
 def _check_adapter_fields(yaml_text: str) -> list[str]:

--- a/tests/fixtures/heartbeat_canonical_body.md
+++ b/tests/fixtures/heartbeat_canonical_body.md
@@ -19,8 +19,7 @@ Over time, this file becomes your personal heartbeat procedure — the steps you
 **Do not** use this file for:
 - Role identity → that's `SOUL.md`.
 - Tool references → that's `TOOLS.md`.
-- Company rules → that's `OPERATIONS.md` and `COMPANY.md`.
-- Daily activity notes → that's `memory/<date>.md` via the `para-memory-files` skill.
+- Your mandate, decision rights, idle-state protocol, and operating rules → those are in `AGENTS.md`.
 
 ---
 
@@ -36,6 +35,6 @@ Over time, this file becomes your personal heartbeat procedure — the steps you
 
 ---
 
-## Critical rules summary
+## Notes to self
 
-*(Empty — echo the most-load-bearing rules from `OPERATIONS.md` and your own `SOUL.md` here once you have a stable wakeup flow.)*
+*(Empty — jot any load-bearing rule you rediscover during real wakeups here. Your authoritative rules live in `AGENTS.md`.)*

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -206,6 +206,9 @@ def test_parse_valid_brief() -> None:
     assert len(brief.we_are_not) == 2
     assert len(brief.constraints) == 2
     assert brief.use_case_pattern == "custom"
+    # Section-7 "Notes if customizing the pattern" prose is captured (the binding
+    # org-customization channel threaded into org_planner — ADR-022 US3 follow-up).
+    assert brief.use_case_notes == "Keep it lean."
     assert brief.governance_position == "balanced"
     assert brief.hours_per_week == 6
     assert brief.capital_monthly_eur == 150

--- a/tests/test_object_model_constitution.py
+++ b/tests/test_object_model_constitution.py
@@ -1,7 +1,8 @@
 """Feature 010 — object-model constitution & governance delivery (ADR-022).
 
-This file covers US2 (no filesystem-read assumptions) and US5 (idle-state correction).
-All offline — no live API. US1/US3/US4 land in later increments.
+This file covers US2 (no filesystem-read assumptions), US5 (idle-state correction), and
+US1 (governance reaches agents via the instruction bundle). All offline — no live API.
+US3/US4 land in later increments.
 """
 
 from __future__ import annotations
@@ -76,3 +77,48 @@ def test_full_fixture_operations_passes_v_idle() -> None:
     config = CompanyConfig(**_full_config_kwargs())
     files = render_files(config)
     assert not any(x.startswith("V-idle") for x in check_schema_shape(config, files))
+
+
+# --- US1: governance reaches agents via the instruction bundle ---------------
+
+
+def test_ceo_agents_md_carries_governance() -> None:
+    ceo = render_files(CompanyConfig(**_full_config_kwargs()))["agents/ceo/AGENTS.md"]
+    for sec in (
+        "## Idle-state protocol",
+        "## Company goals",
+        "## Board-gate and approval",
+        "## Critical rules",
+    ):
+        assert sec in ceo, sec
+    assert "Never ship without sign-off." in ceo  # the critical rule reached the carrier
+
+
+def test_non_ceo_agents_md_has_idle_but_not_ceo_sections() -> None:
+    cto = render_files(CompanyConfig(**_full_config_kwargs()))["agents/cto/AGENTS.md"]
+    assert "## Idle-state protocol" in cto
+    for sec in ("## Company goals", "## Board-gate and approval", "## Critical rules"):
+        assert sec not in cto
+
+
+def test_idle_state_protocol_reaches_each_agents_md() -> None:
+    files = render_files(CompanyConfig(**_full_config_kwargs()))
+    assert "Idle is a success state." in files["agents/ceo/AGENTS.md"]
+    assert "Idle is a success state." in files["agents/cto/AGENTS.md"]
+
+
+def test_v_gov_is_clean_on_full_bundle() -> None:
+    config = CompanyConfig(**_full_config_kwargs())
+    files = render_files(config)
+    assert not any(x.startswith("V-gov") for x in check_schema_shape(config, files))
+
+
+def test_v_gov_flags_missing_ceo_governance() -> None:
+    config = CompanyConfig(**_full_config_kwargs())
+    files = render_files(config)
+    files["agents/ceo/AGENTS.md"] = files["agents/ceo/AGENTS.md"].replace(
+        "## Critical rules", "## Removed"
+    )
+    assert any(
+        x.startswith("V-gov") and "Critical rules" in x for x in check_schema_shape(config, files)
+    )

--- a/tests/test_object_model_constitution.py
+++ b/tests/test_object_model_constitution.py
@@ -122,3 +122,20 @@ def test_v_gov_flags_missing_ceo_governance() -> None:
     assert any(
         x.startswith("V-gov") and "Critical rules" in x for x in check_schema_shape(config, files)
     )
+
+
+# --- US3: the hiring board-gate ships as a structured company setting ---------
+
+
+def test_paperclip_yaml_sets_the_hiring_board_gate() -> None:
+    y = render_files(CompanyConfig(**_full_config_kwargs()))[".paperclip.yaml"]
+    assert "requireBoardApprovalForNewAgents: true" in y
+
+
+def test_s14_flags_a_missing_hiring_gate() -> None:
+    config = CompanyConfig(**_full_config_kwargs())
+    files = render_files(config)
+    files[".paperclip.yaml"] = files[".paperclip.yaml"].replace(
+        "requireBoardApprovalForNewAgents: true", "requireBoardApprovalForNewAgents: false"
+    )
+    assert any(x.startswith("S14") for x in check_schema_shape(config, files))

--- a/tests/test_object_model_constitution.py
+++ b/tests/test_object_model_constitution.py
@@ -1,0 +1,78 @@
+"""Feature 010 — object-model constitution & governance delivery (ADR-022).
+
+This file covers US2 (no filesystem-read assumptions) and US5 (idle-state correction).
+All offline — no live API. US1/US3/US4 land in later increments.
+"""
+
+from __future__ import annotations
+
+from paperclip_blueprints.generators.client import load_prompt
+from paperclip_blueprints.models.output import CompanyConfig
+from paperclip_blueprints.renderers.render import render_files
+from paperclip_blueprints.validators.schema_shape import _check_idle_state, check_schema_shape
+from test_models import _full_config_kwargs
+from test_templates import _config
+
+_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>", "para-memory-files")
+
+
+# --- US2: no filesystem-read assumptions; HEARTBEAT empty --------------------
+
+
+def test_tools_md_has_no_filesystem_section() -> None:
+    tools = render_files(_config())["agents/ceo/TOOLS.md"]
+    for marker in _FS_MARKERS:
+        assert marker not in tools, marker
+    # the company-tree secrets phrasing is gone too
+    assert "company tree" not in tools
+
+
+def test_heartbeat_has_no_file_or_rules_refs() -> None:
+    hb = render_files(_config())["agents/ceo/HEARTBEAT.md"]
+    for bad in ("OPERATIONS.md", "memory/<date>", "para-memory-files"):
+        assert bad not in hb
+    # rules now live in AGENTS.md, not echoed from OPERATIONS.md here
+    assert "AGENTS.md" in hb
+
+
+def test_s13_is_clean_on_a_generated_bundle() -> None:
+    config = _config()
+    files = render_files(config)
+    assert not any(x.startswith("S13") for x in check_schema_shape(config, files))
+
+
+def test_s13_flags_an_injected_filesystem_ref() -> None:
+    config = _config()
+    files = render_files(config)
+    files["agents/ceo/TOOLS.md"] += "\n## File system\n- Company root: `x/`\n"
+    assert any(x.startswith("S13") for x in check_schema_shape(config, files))
+
+
+# --- US5: idle-state protocol correction -------------------------------------
+
+
+def test_operations_prompt_corrects_idle_state() -> None:
+    p = load_prompt("operations_generator").lower()
+    assert "never" in p and "in_progress" in p
+    assert "schedule" in p  # the routine schedule is the liveness
+    assert "zero output" in p or "one short-lived issue" in p
+
+
+def test_v_idle_rejects_in_progress_as_liveness() -> None:
+    bad = "Leave the issue in_progress when a routine is the live continuation path."
+    assert _check_idle_state(bad)
+
+
+def test_v_idle_passes_the_corrected_protocol() -> None:
+    ok = (
+        "Idle is a success state: one short-lived issue per routine run, closed that run; "
+        "never leave an issue in_progress as a liveness marker (the schedule is the liveness); "
+        "zero output on empty wakes."
+    )
+    assert _check_idle_state(ok) == []
+
+
+def test_full_fixture_operations_passes_v_idle() -> None:
+    config = CompanyConfig(**_full_config_kwargs())
+    files = render_files(config)
+    assert not any(x.startswith("V-idle") for x in check_schema_shape(config, files))

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -151,3 +151,37 @@ def test_agents_prompt_encodes_board_gate_and_ownership() -> None:
     assert "board" in low and "must_escalate" in low
     assert "ready for board review" in low
     assert "primary owner" in low and "backstop" in low
+
+
+# --- routines: org_planner sets recurrence only for scheduled work (ADR-022 US3) -----------
+
+
+def test_org_planner_recurrence_rule_is_scheduled_work_only() -> None:
+    text = load_prompt("org_planner")
+    low = text.lower()
+    assert "recurrence" in low
+    # gated to genuinely scheduled standing work, default null
+    assert "null" in low and ("standing schedule" in low or "scheduled" in low)
+    # the cadence vocabulary incl. a weekday-list example
+    assert "mon,wed,fri" in low
+    assert '"recurrence"' in text  # emitted in the task output shape
+
+
+def test_org_planner_treats_customization_notes_as_binding() -> None:
+    low = load_prompt("org_planner").lower()
+    assert "{{ use_case_notes }}" in load_prompt("org_planner")  # the notes reach the prompt
+    assert "binding" in low
+    assert "roster" in low and "headcount" in low
+    # an explicit roster must not be expanded or split into sub-teams
+    assert "do not add roles" in low or "exactly the stated agents" in low
+    assert "sub-team" in low
+
+
+def test_org_planner_one_cadence_one_recurring_task() -> None:
+    low = load_prompt("org_planner").lower()
+    assert "one cadence" in low and "one recurring task" in low
+    # a single scheduled activity must not become multiple recurring tasks
+    assert "do not split" in low
+    assert "sub-step" in low and ("fold" in low or "handoff" in low)
+    # genuinely-distinct cadences still get separate recurring tasks
+    assert "distinct cadences" in low

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -1,71 +1,163 @@
-"""Focused tests for the PROVISIONAL routines emission (ADR-022, US3).
+"""Focused tests for the PROVISIONAL routines emission (ADR-022, US3) — tasks-driven.
 
-Isolated on purpose: a live-import correction to the routine shape should be a contained,
-single-file change to ``renderers/routines.py`` (+ this test file). All offline.
+Routines come from tasks that carry a `recurrence` cadence: each becomes a `.paperclip.yaml`
+routines.<task-slug> block, and the existing TASK.md is flagged `recurring: true` (no shadow
+task). The cron honors the cadence; cron validity + the routines shape stay live-confirm only.
+All offline. Isolated so a live correction is a contained, single-file change.
 """
 
 from __future__ import annotations
 
 from paperclip_blueprints.models.output import CompanyConfig
+from paperclip_blueprints.models.task import TaskDefinition
 from paperclip_blueprints.renderers.render import render_files
-from paperclip_blueprints.renderers.routines import derive_routines, routine_task_files
+from paperclip_blueprints.renderers.routines import cron_for, derive_routines
+from paperclip_blueprints.validators.schema_shape import check_schema_shape
 from test_models import _full_config_kwargs
+from test_templates import _config
 
 
-def test_derive_routines_maps_slot_to_spec() -> None:
-    specs = derive_routines(["ceo: weekly review"], {"ceo", "cto"}, ["launch-v1"])
-    assert len(specs) == 1
-    r = specs[0]
-    assert r.assignee == "ceo"
-    assert r.project == "launch-v1"  # provisional anchor: first project
-    assert r.slug == "ceo-weekly-review"
-    assert r.cron == "0 9 * * 1"  # weekly cadence keyword
-    assert r.timezone == "UTC"
-    assert r.concurrency_policy == "coalesce_if_active"
-    assert r.catch_up_policy == "skip_missed"
+def _task(
+    slug: str, name: str, recurrence: str | None = None, assignee: str = "cto"
+) -> TaskDefinition:
+    return TaskDefinition(
+        slug=slug,
+        name=name,
+        project="launch-v1",  # a real project in the full fixture
+        assignee=assignee,  # "cto"/"ceo" are real agents in the full fixture
+        objective="o",
+        completion_criteria=["done"],
+        recurrence=recurrence,
+    )
 
 
-def test_derive_routines_cadence_keywords() -> None:
-    def cron(slot: str) -> str:
-        return derive_routines([slot], {"a"}, ["p"])[0].cron
-
-    assert cron("a: daily standup") == "0 9 * * *"
-    assert cron("a: monthly report") == "0 9 1 * *"
-    assert cron("a: something custom") == "0 9 * * 1"  # weekly fallback
+# --- cadence → cron translator ----------------------------------------------
 
 
-def test_derive_routines_empty_without_project_or_unknown_agent() -> None:
-    assert derive_routines(["ceo: weekly review"], {"ceo"}, []) == []  # no project to anchor
-    assert derive_routines(["ghost: weekly"], {"ceo"}, ["p"]) == []  # unknown agent
+def test_cron_for_named_cadences() -> None:
+    assert cron_for("daily") == "0 9 * * *"
+    assert cron_for("weekly") == "0 9 * * 1"
+    assert cron_for("monthly") == "0 9 1 * *"
+    assert cron_for("quarterly") == "0 9 1 1,4,7,10 *"
 
 
-def test_derive_routines_dedupes_slugs() -> None:
-    specs = derive_routines(["ceo: review", "ceo: review"], {"ceo"}, ["p"])
-    assert [s.slug for s in specs] == ["ceo-review", "ceo-review-2"]
+def test_cron_for_weekday_list_honors_the_brief_cadence() -> None:
+    assert cron_for("mon,wed,fri") == "0 9 * * 1,3,5"
+    assert cron_for("Monday, Wednesday, Friday") == "0 9 * * 1,3,5"
+    assert cron_for("tue/thu") == "0 9 * * 2,4"
 
 
-def test_routine_task_files_carry_required_frontmatter() -> None:
-    specs = derive_routines(["ceo: weekly review"], {"ceo"}, ["launch-v1"])
-    files = routine_task_files(specs)
-    task = files["tasks/ceo-weekly-review/TASK.md"]
-    assert "recurring: true" in task
-    assert "assignee: ceo" in task
-    assert "project: launch-v1" in task
-    assert "schema: agentcompanies/v1" in task
+def test_cron_for_unknown_falls_back_to_weekly() -> None:
+    assert cron_for("whenever") == "0 9 * * 1"
 
 
-def test_routines_block_and_recurring_task_emitted_in_full_bundle() -> None:
-    files = render_files(CompanyConfig(**_full_config_kwargs()))
+# --- derive_routines (tasks-driven) -----------------------------------------
+
+
+def test_derive_routines_emits_only_recurring_tasks() -> None:
+    tasks = [
+        _task("scan-infra-landscape", "Scan the infra landscape"),  # not recurring
+        _task("signal-scan", "Signal scan", recurrence="mon,wed,fri"),
+        _task("board-package", "Monthly board package", recurrence="monthly"),
+    ]
+    routines = derive_routines(tasks)
+    assert [r.slug for r in routines] == ["signal-scan", "board-package"]  # short, real slugs
+    assert routines[0].cron == "0 9 * * 1,3,5"
+    assert routines[1].cron == "0 9 1 * *"
+
+
+def test_derive_routines_inherits_task_assignee_and_project() -> None:
+    # Part-2 acceptance: each routine resolves a real assignee + project from its task.
+    (routine,) = derive_routines([_task("signal-scan", "Signal scan", recurrence="mon,wed,fri")])
+    assert routine.assignee == "cto"
+    assert routine.project == "launch-v1"
+
+
+def test_derive_routines_empty_when_no_task_is_scheduled() -> None:
+    assert derive_routines([_task("ship", "Ship"), _task("review", "Review")]) == []
+
+
+# --- render: one task set, recurring flagged, routines keyed off real slug ---
+
+
+def test_recurring_task_renders_routine_block_and_recurring_flag() -> None:
+    config = CompanyConfig(
+        **_full_config_kwargs(
+            tasks=[
+                _task("ship", "Ship"),
+                _task("signal-scan", "Signal scan", recurrence="mon,wed,fri"),
+            ]
+        )
+    )
+    files = render_files(config)
     y = files[".paperclip.yaml"]
     assert "routines:" in y
-    assert "ceo-weekly-review:" in y
-    assert 'cronExpression: "0 9 * * 1"' in y
-    assert "tasks/ceo-weekly-review/TASK.md" in files
+    assert "signal-scan:" in y
+    assert 'cronExpression: "0 9 * * 1,3,5"' in y
+    # the recurring task is the EXISTING task, flagged — no shadow task
+    assert "recurring: true" in files["tasks/signal-scan/TASK.md"]
+    assert "recurring: true" not in files["tasks/ship/TASK.md"]
+    # one task set: exactly the two declared tasks, no extra routine task dir
+    task_dirs = {p.split("/")[1] for p in files if p.startswith("tasks/")}
+    assert task_dirs == {"ship", "signal-scan"}
+
+
+def test_no_recurring_task_means_no_routines_block() -> None:
+    files = render_files(CompanyConfig(**_full_config_kwargs()))  # fixture "ship" is not recurring
+    assert "routines:" not in files[".paperclip.yaml"]
+    assert "recurring: true" not in files["tasks/ship/TASK.md"]
 
 
 def test_single_agent_bundle_has_no_routines() -> None:
-    from test_templates import _config
-
-    files = render_files(_config())  # single-agent: no operations → no routines
+    files = render_files(_config())  # single-agent: no tasks
     assert "routines:" not in files[".paperclip.yaml"]
     assert not any(p.startswith("tasks/") for p in files)
+
+
+# --- S15 routines closure ----------------------------------------------------
+
+
+def test_s15_clean_when_routines_match_recurring_tasks() -> None:
+    config = CompanyConfig(
+        **_full_config_kwargs(
+            tasks=[_task("ship", "Ship"), _task("signal-scan", "Signal scan", recurrence="weekly")]
+        )
+    )
+    files = render_files(config)
+    assert not any(x.startswith("S15") for x in check_schema_shape(config, files))
+
+
+def test_s15_flags_an_orphan_routine_block() -> None:
+    config = CompanyConfig(**_full_config_kwargs())  # no recurring task → no routines
+    files = render_files(config)
+    files[".paperclip.yaml"] += "\nroutines:\n  ghost:\n    triggers: []\n"
+    assert any(x.startswith("S15") and "ghost" in x for x in check_schema_shape(config, files))
+
+
+# --- soft warning: a split scheduled activity (same cadence + assignee) ------
+
+
+def _warnings_for(*tasks: TaskDefinition) -> list[str]:
+    config = CompanyConfig(**_full_config_kwargs(tasks=list(tasks)))
+    captured: list[str] = []
+    render_files(config, warn=captured.append)
+    return captured
+
+
+def test_same_cadence_same_assignee_routines_warn() -> None:
+    warnings = _warnings_for(
+        _task("scan-landscape", "Scan", recurrence="mon,wed,fri", assignee="cto"),
+        _task("log-signal-patterns", "Log", recurrence="mon,wed,fri", assignee="cto"),
+    )
+    smell = [w for w in warnings if "split into multiple recurring" in w]
+    assert smell, warnings
+    assert "scan-landscape" in smell[0] and "log-signal-patterns" in smell[0]
+    assert "one-cadence rule" in smell[0]
+
+
+def test_same_cadence_different_assignee_routines_do_not_warn() -> None:
+    warnings = _warnings_for(
+        _task("scan-landscape", "Scan", recurrence="mon,wed,fri", assignee="cto"),
+        _task("board-package", "Board", recurrence="mon,wed,fri", assignee="ceo"),
+    )
+    assert not any("split into multiple recurring" in w for w in warnings)

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -1,0 +1,71 @@
+"""Focused tests for the PROVISIONAL routines emission (ADR-022, US3).
+
+Isolated on purpose: a live-import correction to the routine shape should be a contained,
+single-file change to ``renderers/routines.py`` (+ this test file). All offline.
+"""
+
+from __future__ import annotations
+
+from paperclip_blueprints.models.output import CompanyConfig
+from paperclip_blueprints.renderers.render import render_files
+from paperclip_blueprints.renderers.routines import derive_routines, routine_task_files
+from test_models import _full_config_kwargs
+
+
+def test_derive_routines_maps_slot_to_spec() -> None:
+    specs = derive_routines(["ceo: weekly review"], {"ceo", "cto"}, ["launch-v1"])
+    assert len(specs) == 1
+    r = specs[0]
+    assert r.assignee == "ceo"
+    assert r.project == "launch-v1"  # provisional anchor: first project
+    assert r.slug == "ceo-weekly-review"
+    assert r.cron == "0 9 * * 1"  # weekly cadence keyword
+    assert r.timezone == "UTC"
+    assert r.concurrency_policy == "coalesce_if_active"
+    assert r.catch_up_policy == "skip_missed"
+
+
+def test_derive_routines_cadence_keywords() -> None:
+    def cron(slot: str) -> str:
+        return derive_routines([slot], {"a"}, ["p"])[0].cron
+
+    assert cron("a: daily standup") == "0 9 * * *"
+    assert cron("a: monthly report") == "0 9 1 * *"
+    assert cron("a: something custom") == "0 9 * * 1"  # weekly fallback
+
+
+def test_derive_routines_empty_without_project_or_unknown_agent() -> None:
+    assert derive_routines(["ceo: weekly review"], {"ceo"}, []) == []  # no project to anchor
+    assert derive_routines(["ghost: weekly"], {"ceo"}, ["p"]) == []  # unknown agent
+
+
+def test_derive_routines_dedupes_slugs() -> None:
+    specs = derive_routines(["ceo: review", "ceo: review"], {"ceo"}, ["p"])
+    assert [s.slug for s in specs] == ["ceo-review", "ceo-review-2"]
+
+
+def test_routine_task_files_carry_required_frontmatter() -> None:
+    specs = derive_routines(["ceo: weekly review"], {"ceo"}, ["launch-v1"])
+    files = routine_task_files(specs)
+    task = files["tasks/ceo-weekly-review/TASK.md"]
+    assert "recurring: true" in task
+    assert "assignee: ceo" in task
+    assert "project: launch-v1" in task
+    assert "schema: agentcompanies/v1" in task
+
+
+def test_routines_block_and_recurring_task_emitted_in_full_bundle() -> None:
+    files = render_files(CompanyConfig(**_full_config_kwargs()))
+    y = files[".paperclip.yaml"]
+    assert "routines:" in y
+    assert "ceo-weekly-review:" in y
+    assert 'cronExpression: "0 9 * * 1"' in y
+    assert "tasks/ceo-weekly-review/TASK.md" in files
+
+
+def test_single_agent_bundle_has_no_routines() -> None:
+    from test_templates import _config
+
+    files = render_files(_config())  # single-agent: no operations → no routines
+    assert "routines:" not in files[".paperclip.yaml"]
+    assert not any(p.startswith("tasks/") for p in files)


### PR DESCRIPTION
Makes generated bundles run **governed** on a real Paperclip UI import (database-backed, no company-root filesystem), per ADR-022 — plus the tasks-driven routines correction the acceptance gate anticipated. Offline checks pass, the bundle imports cleanly, **295 passed / 2 skipped**, ruff/format/pyright clean.

## What's in
- **US1** — governance folded into each agent's `AGENTS.md` per role (CEO: board-gate + critical rules + company goals; others: own anti-drift + decision rights + idle-state); persona anti-drift in `SOUL.md`. Validator **V-gov**.
- **US2** — removed the company-root filesystem assumptions from `TOOLS.md`/`HEARTBEAT.md` (agents were told to read files a DB import never creates); `HEARTBEAT.md` stays empty. Validator **S13**.
- **US5** — corrected idle-state protocol (never `in_progress` as a liveness marker). Validator **V-idle**.
- **US3** — hiring board-gate as a `.paperclip.yaml` `requireBoardApprovalForNewAgents` setting (**S14**); **tasks-driven routines**: a task's `recurrence` cadence → a `routines.<task-slug>` block (cron from the cadence) + the existing task flagged `recurring: true` (no shadow tasks); **S15** closure; a soft cadence-collision warning.
- **US4** — docs reconciled: `OPERATIONS.md` is human/operator docs (ADR-002 revised); CLAUDE.md deployment-model reframed.
- **Section-7 notes** now captured (`use_case_notes`) and treated as **binding** by org_planner (explicit roster / headcount cap / stated cadence drives the org); **one-cadence → one recurring task** rule.
- **Docs**: README (object-model semantics + routines), input-template (binding §7 notes), plus the plain-value placeholder fix (backticks) folded in.

Deferred / out of scope: the `hermes_local` adapter work (next branch, off merged main); cron string / `routines.<slug>` shape remain live-import-confirmed; the ADR-017 Hermes amendment is parked for the hermes_local branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)