### PR TITLE
fix: honor explicit per-role model preferences in .paperclip.yaml

### DIFF
--- a/docs/adr/017-per-agent-model-id.md
+++ b/docs/adr/017-per-agent-model-id.md
@@ -101,10 +101,12 @@ agents:
    out to require `env` at import (so type+model-without-env breaks import), **stop
    and report — do not emit `env` to compensate.**
 
-5. **Deferred (out of scope for v0.1).** Parsing the free-text
-   `input.adapter_preferences` into structured per-role overrides; `opencode_local`
-   + Manifest routing; `hermes_local` for persistent-memory roles. These need
-   instance/env knowledge and stay with the v0.2 deployer (`adapter_assigner.py`).
+5. **Deferred (out of scope for v0.1).** ~~Parsing the free-text
+   `input.adapter_preferences` into structured per-role overrides~~ — the per-role **model
+   tier** part is **now honored in v0.1** (see the 2026-07-01 amendment below); `opencode_local`
+   + Manifest routing and adapter-**type** overrides (`codex_local`/`hermes_local` per role)
+   remain deferred — they need instance/env knowledge and stay with the v0.2 deployer
+   (`adapter_assigner.py`).
 
 ## Consequences
 
@@ -141,6 +143,23 @@ agents:
 - **Add a per-agent model field to `AgentDefinition`.** Rejected (YAGNI) — the
   assignment is a render-time derivation from the role bucket, like budgets; no
   model change.
+
+## Amendment — 2026-07-01: per-role model preferences honored (was deferred)
+
+The coarse four-bucket role→model default (owner→Opus, every other role→Sonnet) silently
+ignored the brief's explicit per-role model preferences (section 10 `adapter_preferences`), so a
+brief that requested e.g. `Senior Analyst → Opus-tier` shipped `claude-sonnet-4-6` in
+`.paperclip.yaml` — output that contradicted the brief. Fixed in v0.1: `renderers/adapter.py`
+`parse_model_preferences` resolves each `adapter_preferences` line that names a Claude **tier**
+(`opus`→`OPUS_MODEL`, `sonnet`→`SONNET_MODEL`) to the agent(s) it references (boundary-safe
+slug / title-slug / name-slug, most-specific match), and `assign_adapters` applies it as a
+per-slug **model** override — the adapter **type** stays the env-free, import-safe default, so
+the no-`env` / type-allowlist rules (Decision §1, S12) are unchanged. Unspecified roles keep the
+coarse default; a tier line matching no agent is surfaced through the render `warn` sink.
+
+Adapter-**type** preferences (`codex_local`/`hermes_local`/`opencode_local`, Manifest routing)
+remain deferred to the v0.2 deployer (they need instance/env knowledge). This amendment removes
+only the **model-tier** part from Decision §5's deferred list.
 
 ## References
 

--- a/src/paperclip_blueprints/renderers/adapter.py
+++ b/src/paperclip_blueprints/renderers/adapter.py
@@ -12,7 +12,9 @@ preferences and are not validated by the importer for these worker kinds.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import Protocol
 
 from ..config import (
     ADAPTER_CLAUDE_LOCAL,
@@ -21,6 +23,15 @@ from ..config import (
     OPUS_MODEL,
     SONNET_MODEL,
 )
+from ..paperclip_slug import slugify_project_name
+
+
+class _AgentRef(Protocol):
+    """The only agent attributes the preference matcher reads — ``AgentDefinition`` satisfies it."""
+
+    slug: str
+    title: str
+    name: str
 
 
 @dataclass(frozen=True)
@@ -49,15 +60,92 @@ _BY_ROLE: dict[str, AdapterChoice] = {
 CODEX_ALTERNATIVE = AdapterChoice(ADAPTER_CODEX_LOCAL, CODEX_MODEL)
 
 
-def assign_adapters(role_by_slug: dict[str, str]) -> dict[str, AdapterChoice]:
+def assign_adapters(
+    role_by_slug: dict[str, str], model_overrides: dict[str, str] | None = None
+) -> dict[str, AdapterChoice]:
     """Map each agent's role bucket to its portable ``(type, model)`` preference.
 
     Args:
         role_by_slug: agent slug -> role bucket
             ("owner" | "manager" | "engineering" | "generic").
+        model_overrides: slug -> model id, from the brief's explicit per-role model
+            preferences (see :func:`parse_model_preferences`). Overrides the coarse
+            role default's **model** for the named roles; the adapter **type** stays
+            the env-free, import-safe default (ADR-017 unchanged).
 
     Returns:
         slug -> :class:`AdapterChoice`, covering exactly the input agents. Every
         ``type`` is an env-free, import-safe worker kind; no ``env`` is produced.
     """
-    return {slug: _BY_ROLE[bucket] for slug, bucket in role_by_slug.items()}
+    overrides = model_overrides or {}
+    result: dict[str, AdapterChoice] = {}
+    for slug, bucket in role_by_slug.items():
+        default = _BY_ROLE[bucket]
+        result[slug] = AdapterChoice(default.type, overrides.get(slug, default.model))
+    return result
+
+
+# Claude model tier keyword (in a preference line) -> full model id. Only the Claude
+# *tier* is honored here; adapter-*type* overrides (codex/hermes/opencode/Manifest) need
+# instance/env knowledge and stay v0.2-deployer territory (ADR-017).
+_TIER_MODELS = ((("opus",), OPUS_MODEL), (("sonnet",), SONNET_MODEL))
+
+
+def _tier_model(line_lower: str) -> str | None:
+    for keywords, model in _TIER_MODELS:
+        if any(k in line_lower for k in keywords):
+            return model
+    return None
+
+
+def _boundary_contains(haystack_slug: str, needle_slug: str) -> bool:
+    """True if ``needle_slug`` appears as a whole hyphen-delimited run in ``haystack_slug``.
+
+    Boundary match so agent ``analyst`` is not matched by a line about ``senior-analyst``.
+    """
+    return bool(needle_slug) and f"-{needle_slug}-" in f"-{haystack_slug}-"
+
+
+def _matched_ref(agent: _AgentRef, line_slug: str) -> str | None:
+    """The longest of the agent's slug / title-slug / name-slug that boundary-matches the line."""
+    refs = [agent.slug, slugify_project_name(agent.title), slugify_project_name(agent.name)]
+    matched = [r for r in refs if _boundary_contains(line_slug, r)]
+    return max(matched, key=len) if matched else None
+
+
+def parse_model_preferences(
+    preferences: Sequence[str] | None, agents: Sequence[_AgentRef]
+) -> tuple[dict[str, str], list[str]]:
+    """Resolve the brief's per-role model preferences to per-slug model overrides.
+
+    For each ``adapter_preferences`` line that names a Claude tier (``opus``/``sonnet``),
+    match it to the agent(s) it references by boundary-safe slug / title-slug / name-slug, and
+    record a model override. Lines with no Claude tier are skipped (adapter-type/provider notes
+    stay v0.2). A line can legitimately name several distinct roles for one tier; a role whose
+    matched ref is *nested* inside another matched role's ref (e.g. ``analyst`` inside
+    ``senior-analyst``) is dropped so only the most-specific role is taken.
+
+    Returns ``(overrides, unmatched)`` — ``overrides`` maps slug -> model id; ``unmatched``
+    lists tier-naming lines that matched no agent (a likely typo the caller can warn about).
+    """
+    if not preferences:
+        return {}, []
+    overrides: dict[str, str] = {}
+    unmatched: list[str] = []
+    for line in preferences:
+        model = _tier_model(line.lower())
+        if model is None:
+            continue
+        line_slug = slugify_project_name(line)
+        matched = [(a.slug, ref) for a in agents if (ref := _matched_ref(a, line_slug))]
+        kept = [
+            slug
+            for slug, ref in matched
+            if not any(other != ref and _boundary_contains(other, ref) for _, other in matched)
+        ]
+        if kept:
+            for slug in kept:
+                overrides[slug] = model
+        else:
+            unmatched.append(line)
+    return overrides, unmatched

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -19,7 +19,7 @@ from ..models.output import CompanyConfig
 from ..models.project import ProjectDefinition
 from ..models.skill import SkillDefinition
 from ..models.task import TaskDefinition
-from .adapter import assign_adapters
+from .adapter import assign_adapters, parse_model_preferences
 from .budget import allocate_budgets
 from .frontmatter import dump_frontmatter
 from .routines import RoutineSpec, derive_routines
@@ -181,7 +181,19 @@ def render_files(
 
     # Per-agent portable model preference (ADR-017): (adapter type, model id) derived
     # from the same role buckets, emitted under each agent's `adapter`. Never `env`.
-    adapters = assign_adapters(role_by_slug)
+    # Explicit per-role model preferences from the brief (section 10 adapter_preferences)
+    # override the coarse role default's MODEL for the named roles; unspecified roles keep
+    # the default. Adapter type is unchanged (env-free, import-safe).
+    model_overrides, unmatched_prefs = parse_model_preferences(
+        config.brief.adapter_preferences, config.agents
+    )
+    adapters = assign_adapters(role_by_slug, model_overrides)
+    if warn is not None:
+        for line in unmatched_prefs:
+            warn(
+                f"adapter preference {line!r} names a model tier but matched no agent role — "
+                "that role keeps its default model"
+            )
 
     # Tasks with a `recurrence` cadence → importable Routines (ADR-022, US3, PROVISIONAL cron):
     # a `.paperclip.yaml` routines.<task-slug> block; the recurring task itself is flagged

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,7 +1,26 @@
 """Unit tests for the per-agent model-preference assigner (ADR-017, contract A1-A7)."""
 
-from paperclip_blueprints.config import PORTABLE_ADAPTER_TYPES
-from paperclip_blueprints.renderers.adapter import AdapterChoice, assign_adapters
+from dataclasses import dataclass
+
+from paperclip_blueprints.config import OPUS_MODEL, PORTABLE_ADAPTER_TYPES, SONNET_MODEL
+from paperclip_blueprints.models.input import CompanyBrief
+from paperclip_blueprints.models.output import CompanyConfig
+from paperclip_blueprints.renderers.adapter import (
+    AdapterChoice,
+    assign_adapters,
+    parse_model_preferences,
+)
+from paperclip_blueprints.renderers.render import render_files
+from test_models import _brief_kwargs, _full_config_kwargs
+
+
+@dataclass
+class _Ag:
+    """Minimal agent stand-in — parse_model_preferences reads only slug/title/name."""
+
+    slug: str
+    title: str
+    name: str
 
 
 def test_owner_gets_claude_local_opus() -> None:
@@ -49,3 +68,79 @@ def test_covers_exactly_the_input_agents() -> None:
 def test_deterministic() -> None:
     roles = {"ceo": "owner", "eng": "engineering", "ops": "generic"}
     assert assign_adapters(roles) == assign_adapters(roles)
+
+
+# --- honoring explicit per-role model preferences (v0.1, refines ADR-017) ----
+
+
+def test_explicit_non_owner_opus_preference_overrides_the_default() -> None:
+    agents = [_Ag("senior-analyst", "Senior Analyst", "Senior Analyst")]
+    overrides, unmatched = parse_model_preferences(["Senior Analyst → Opus-tier"], agents)
+    assert overrides == {"senior-analyst": OPUS_MODEL}
+    assert unmatched == []
+    # applied: the role's MODEL flips to Opus; the TYPE stays the env-free default.
+    out = assign_adapters({"senior-analyst": "generic"}, overrides)
+    assert out["senior-analyst"] == AdapterChoice("claude_local", "claude-opus-4-8")
+
+
+def test_unspecified_roles_keep_the_default() -> None:
+    agents = [_Ag("cto", "CTO", "CTO"), _Ag("analyst", "Analyst", "Analyst")]
+    overrides, _ = parse_model_preferences(["CTO → Sonnet-tier"], agents)
+    out = assign_adapters({"ceo": "owner", "cto": "manager", "analyst": "generic"}, overrides)
+    assert out["ceo"] == AdapterChoice("claude_local", OPUS_MODEL)  # owner default untouched
+    assert out["cto"] == AdapterChoice("claude_local", SONNET_MODEL)  # explicit (== default here)
+    assert out["analyst"] == AdapterChoice("claude_local", SONNET_MODEL)  # default
+
+
+def test_override_keeps_type_import_safe_and_no_env() -> None:
+    out = assign_adapters({"analyst": "generic"}, {"analyst": OPUS_MODEL})
+    assert out["analyst"].type in PORTABLE_ADAPTER_TYPES
+    assert not hasattr(out["analyst"], "env")
+
+
+def test_matches_by_title_when_slug_differs() -> None:
+    agents = [_Ag("sa", "Senior Analyst", "Ana")]
+    overrides, unmatched = parse_model_preferences(["Senior Analyst → Opus-tier"], agents)
+    assert overrides == {"sa": OPUS_MODEL} and unmatched == []
+
+
+def test_boundary_match_avoids_substring_false_positive() -> None:
+    agents = [_Ag("analyst", "Analyst", "Analyst"), _Ag("senior-analyst", "Senior Analyst", "SA")]
+    overrides, _ = parse_model_preferences(["senior-analyst → Opus"], agents)
+    assert overrides == {"senior-analyst": OPUS_MODEL}  # not "analyst"
+
+
+def test_non_tier_line_is_skipped_not_unmatched() -> None:
+    agents = [_Ag("eng", "Engineer", "Eng")]
+    overrides, unmatched = parse_model_preferences(["All engineers → codexlocal"], agents)
+    assert overrides == {} and unmatched == []
+
+
+def test_tier_line_matching_no_agent_is_reported_unmatched() -> None:
+    agents = [_Ag("ceo", "CEO", "CEO")]
+    overrides, unmatched = parse_model_preferences(["Ghost Role → Opus-tier"], agents)
+    assert overrides == {} and unmatched == ["Ghost Role → Opus-tier"]
+
+
+def test_no_preferences_returns_defaults() -> None:
+    assert parse_model_preferences(None, [_Ag("ceo", "CEO", "CEO")]) == ({}, [])
+
+
+# --- end-to-end through render_files → .paperclip.yaml ------------------------
+
+
+def test_paperclip_yaml_honors_a_non_owner_opus_preference() -> None:
+    brief = CompanyBrief(**_brief_kwargs(adapter_preferences=["CTO → Opus-tier"]))
+    config = CompanyConfig(**_full_config_kwargs(brief=brief))
+    y = render_files(config)[".paperclip.yaml"]
+    # the CTO (a non-owner, Sonnet by default) now ships Opus in .paperclip.yaml
+    cto_block = y[y.index("cto:") : y.index("cto:") + 160]
+    assert "claude-opus-4-8" in cto_block
+
+
+def test_unmatched_preference_warns_via_the_warn_sink() -> None:
+    brief = CompanyBrief(**_brief_kwargs(adapter_preferences=["Nonexistent Role → Opus-tier"]))
+    config = CompanyConfig(**_full_config_kwargs(brief=brief))
+    warnings: list[str] = []
+    render_files(config, warn=warnings.append)
+    assert any("matched no agent role" in w for w in warnings)


### PR DESCRIPTION
## Problem

The adapter renderer (`renderers/adapter.py`) applied a coarse four-bucket role→model default (owner→Opus, every other role→Sonnet) and **silently ignored the brief's explicit per-role model preferences** (section 10 `adapter_preferences`). A brief requesting e.g. `Senior Analyst → Opus-tier` or `Content Producer → Opus-tier` shipped `claude-sonnet-4-6` in `.paperclip.yaml` — a v0.1 generation-correctness bug where output contradicted the brief on `main`.

## Fix

- **`parse_model_preferences(preferences, agents)`** (new, pure): for each `adapter_preferences` line naming a Claude **tier** (`opus`→`OPUS_MODEL`, `sonnet`→`SONNET_MODEL`), resolve it to the agent(s) it references and return `(overrides, unmatched)`.
  - Matching is boundary-safe across the agent's **slug / title-slug / name-slug**, taking the most-specific match, so `analyst` is not matched by a line about `senior-analyst`.
  - A line may name several distinct roles for one tier; a role whose matched ref is *nested* inside another's is dropped.
- **`assign_adapters(role_by_slug, model_overrides=None)`**: applies the overrides as a per-slug **MODEL** swap. The adapter **TYPE** stays the env-free, import-safe default (`claude_local`), so ADR-017's no-`env` / type-allowlist rules (validator **S12**) are **unchanged**.
- **`render.py`**: wires the parse→assign flow and surfaces any tier line that matched no agent through the existing `warn` sink (so a typo doesn't silently fall back to Sonnet).
- Unspecified roles keep the coarse default.

Adapter-**type** preferences (`codex_local`/`hermes_local`/`opencode_local`, Manifest routing) remain **v0.2-deferred** — they need instance/env knowledge.

## Tests (TDD)

Required cases plus edges, in `tests/test_adapter.py`:
- non-owner Opus preference emits Opus for that role; unspecified roles keep the default; override keeps type import-safe with no `env` (ADR-017 rules intact)
- match-by-title when slug differs; boundary match avoids `analyst` ⊂ `senior-analyst` false positive; non-tier line skipped (not unmatched); tier line matching no agent reported unmatched; no-preferences → defaults
- end-to-end through `render_files` → `.paperclip.yaml` honors a non-owner Opus preference; unmatched preference warns via the sink

## Docs

ADR-017 amended (2026-07-01): per-role **model** preferences are now honored rather than deferred; §5 deferred list narrowed to adapter-**type** overrides only.

## Gates

`ruff check` ✅ · `ruff format` ✅ · `pyright` ✅ 0 errors · `pytest` ✅ 305 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)