### PR TITLE
fix: warn (do not fail) on brief slug vs slugify(name) divergence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,10 @@ examples/generated-companies/*
 !examples/generated-companies/.gitkeep
 !examples/generated-companies/example-*/
 
+# Briefs contain real customer/internal content — never commit. Only sanitized example-brief-* are public.
+examples/*brief*.md
+!examples/example-brief-*.md
+
 # Logs
 *.log
 logs/

--- a/src/paperclip_blueprints/cli.py
+++ b/src/paperclip_blueprints/cli.py
@@ -14,7 +14,7 @@ import typer
 from .config import MissingAPIKeyError
 from .generators.client import GenerationError, LLMClient
 from .generators.identity import generate_identity
-from .models.input import BriefValidationError, parse_brief
+from .models.input import BriefValidationError, parse_brief, slug_divergence_warning
 from .renderers.bundle import BundleError, build_and_write
 from .renderers.render import render_company_md
 from .validators import BundleValidationError
@@ -65,6 +65,8 @@ def generate(
     the minimal one-agent bundle (the size-one special case).
     """
     brief = _load_brief(input)
+    if (warning := slug_divergence_warning(brief)) is not None:
+        typer.echo(f"warning: {warning}", err=True)
     if verbose:
         kind = "single-agent" if single_agent else "multi-agent"
         typer.echo(f"brief OK: {brief.name} ({brief.slug}) — generating {kind} bundle", err=True)

--- a/src/paperclip_blueprints/models/input.py
+++ b/src/paperclip_blueprints/models/input.py
@@ -14,6 +14,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ValidationError, field_validator
 
+from ..paperclip_slug import slugify_project_name
+
 GovernancePosition = Literal["tight", "balanced", "loose"]
 
 _SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
@@ -147,6 +149,34 @@ class CompanyBrief(BaseModel):
                 f"unknown use-case pattern {v!r}; available: {', '.join(KNOWN_PATTERNS)}"
             )
         return v
+
+
+def slug_divergence_warning(brief: CompanyBrief) -> str | None:
+    """Return a non-blocking warning if ``brief.slug`` differs from ``slugify(name)``.
+
+    Paperclip may key a company/project on the derived ``slugify(name)`` form, and the
+    v0.2 deployer reconciles on that same derived form (ADR-013). An operator-set
+    ``slug`` that diverges can therefore mis-key on import. This is advisory only:
+    divergence is sometimes intended (e.g. a keying-test company whose name and slug
+    differ on purpose), so the model stays pure and generation still proceeds — the
+    caller (CLI) decides how to surface the string. No printing happens here.
+
+    Args:
+        brief: The parsed, validated company brief.
+
+    Returns:
+        A human-readable warning naming both values, or ``None`` when they already
+        match — or when the name has no derivable ASCII slug (an empty derived form,
+        a separate non-ASCII concern the slug module handles with a UUID suffix).
+    """
+    derived = slugify_project_name(brief.name)
+    if not derived or derived == brief.slug:
+        return None
+    return (
+        f"brief slug {brief.slug!r} differs from slugify(name) {derived!r}; "
+        "Paperclip may key on the derived form while the deployer reconciles on "
+        "slugify(name) — align them unless the divergence is intended."
+    )
 
 
 class BriefValidationError(Exception):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -172,6 +172,22 @@ def test_generate_happy_path(tmp_path, monkeypatch) -> None:
     assert (dest / "agents/ceo/SOUL.md").exists()
 
 
+def test_generate_warns_but_succeeds_on_slug_divergence(tmp_path, monkeypatch) -> None:
+    # A brief whose slug diverges from slugify(name) must still generate (divergence
+    # can be intentional), while surfacing a non-blocking warning on stderr.
+    _patch_client(monkeypatch)
+    brief = tmp_path / "brief.md"
+    brief.write_text(VALID_BRIEF.replace("**Slug:** indie-game-studio", "**Slug:** keying-test"))
+    out = tmp_path / "out"
+    result = runner.invoke(
+        app, ["generate", "--input", str(brief), "--output", str(out), "--single-agent"]
+    )
+    assert result.exit_code == 0, result.output
+    assert "warning:" in result.output
+    assert "keying-test" in result.output
+    assert (out / "COMPANY.md").exists()
+
+
 def test_generate_default_is_full_multi_agent(tmp_path, monkeypatch) -> None:
     _patch_client(monkeypatch, _dispatch_full)
     brief = _write_brief(tmp_path)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -11,6 +11,7 @@ from paperclip_blueprints.models.input import (
     BriefValidationError,
     CompanyBrief,
     parse_brief,
+    slug_divergence_warning,
 )
 from paperclip_blueprints.models.operations import OperationsDefinition
 from paperclip_blueprints.models.org_plan import (
@@ -135,6 +136,29 @@ def test_valid_brief_constructs() -> None:
     brief = CompanyBrief(**_brief_kwargs())
     assert brief.slug == "indie-game-studio"
     assert brief.governance_position == "balanced"
+
+
+def test_slug_divergence_warning_none_when_slug_matches_slugified_name() -> None:
+    # "Indie Game Studio" slugifies to "indie-game-studio" — the default slug.
+    brief = CompanyBrief(**_brief_kwargs())
+    assert slug_divergence_warning(brief) is None
+
+
+def test_slug_divergence_warning_names_both_values_on_divergence() -> None:
+    brief = CompanyBrief(**_brief_kwargs(slug="keying-test"))
+    warning = slug_divergence_warning(brief)
+    assert warning is not None
+    # names both the operator slug and the derived form, and stays advisory
+    assert "keying-test" in warning
+    assert "indie-game-studio" in warning
+    assert "slugify(name)" in warning
+
+
+def test_slug_divergence_warning_none_for_non_ascii_name() -> None:
+    # An all-non-ASCII name has no derivable ASCII slug (slugify → ""), which is a
+    # separate concern — no spurious "differs from ''" warning here.
+    brief = CompanyBrief(**_brief_kwargs(name="株式会社", slug="kabushiki-gaisha"))
+    assert slug_divergence_warning(brief) is None
 
 
 def test_slug_must_be_lowercase_hyphenated() -> None:


### PR DESCRIPTION
## What

A brief carries both an operator-set `slug` and a `name`. Paperclip may key a company/project on the derived `slugify(name)` form, and the deployer reconciles on that same derived form (ADR-013), so a divergent slug can mis-key on import.

Add a **non-blocking** warning: a divergent slug is sometimes intentional (e.g. a keying-test company whose name and slug differ on purpose), so generation must still succeed.

## Changes

- `models/input.py` — new pure `slug_divergence_warning(brief)` helper, reusing `slugify_project_name()`. Returns an advisory string naming both values, or `None` when they match (or when the name has no derivable ASCII slug). The model stays pure — no printing.
- `cli.py` — the `generate` command surfaces the warning via `typer.echo(..., err=True)`; generation proceeds regardless.
- Tests: pure-check tests (match → None, divergence → names both values, non-ASCII → None) and a CLI test asserting generation still succeeds and emits the warning.

## Also (hygiene)

- `.gitignore` — ignore real/internal briefs so only sanitized `example-brief-*.md` fixtures are public. `input-template.md` is unaffected; verified via `git check-ignore`.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)