### PR TITLE
feat: attach built-in Paperclip skills to agents by role (ADR-023)

### DIFF
--- a/docs/adr/023-builtin-skills-by-role.md
+++ b/docs/adr/023-builtin-skills-by-role.md
@@ -1,0 +1,103 @@
+# ADR-023: Attach built-in Paperclip skills to agents by role
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-03
+
+## Context
+
+The generator synthesizes a `skills/<slug>/SKILL.md` for every skill it invents and
+wires each agent's `skills:` list to those generated files. But a Paperclip instance
+already ships a catalog of **built-in** skills that every imported company has, and an
+agent needs the role-appropriate ones to actually function — the control plane
+(`paperclip`: tasks, coordination, governance) and durable cross-wake memory
+(`para-memory-files`) at minimum. Generated bundles never referenced these, so an
+imported agent had no handle on the platform capabilities it was expected to use.
+
+Built-ins are resolved by slug against the instance catalog, not carried in the bundle.
+So they must appear in an agent's skill list (→ `skills:` frontmatter today, and
+`.paperclip.yaml` `desiredSkills` once skill attachment lands — ADR-020, parked) but must
+**not** get a generated `SKILL.md`, and the bundle's skill-closure checks must treat their
+slugs as resolvable without one.
+
+A separate friction point: the S13 anti-filesystem check (ADR-022) listed
+`para-memory-files` as a filesystem-read marker, because the pre-010 prose named that
+skill while assuming a company-root memory tree. Declaring `para-memory-files` as a
+legitimate skill slug now collides with that marker.
+
+## Decision
+
+Introduce a single-source registry and role rule in `patterns/builtins.py`
+(`BUILTIN_SKILLS` plus `builtin_skills_for` / `attach_builtin_skills`), and apply it after
+the org is planned (reportsTo — and thus CEO/lead roles — fixed) and custom skills are
+assigned:
+
+- **All agents** get `paperclip` and `para-memory-files`.
+- **CEO + any lead** (an agent with ≥1 direct report) also get
+  `paperclip-converting-plans-to-tasks`.
+- **CEO only** (org root / `role: ceo`) also gets `paperclip-create-agent`.
+- **Never auto-attached:** `paperclip-board` (the human board member's skill) and
+  `paperclip-dev` (operator / instance ops). They remain recognized built-ins so a
+  hand-authored reference still resolves without a SKILL.md.
+
+Built-ins are appended after an agent's existing custom skills (so `skills[0]` stays the
+primary custom skill, which the single-agent path reads) and de-duplicated, so a built-in
+already listed by the org planner is not doubled.
+
+Built-ins get **no** `SKILL.md`. The single exclusion point is `OrgPlan.skill_slugs`
+(the set that drives skill-generation fan-out), which now filters out `BUILTIN_SKILLS`;
+because a built-in never becomes a `SkillDefinition`, the renderer never creates a
+`skills/<builtin>/` directory. Every skill-closure check treats a built-in slug as valid
+without a bundle file: the `CompanyConfig` model validator, the `I5` integrity check, and
+the legacy `structural_check`.
+
+Finally, `para-memory-files` is removed from the S13 filesystem-read marker set — it is
+now a skill slug, not filesystem prose. The memory-path prose S13 guards against is still
+caught by the `Own memory` / `memory/<date>` markers.
+
+## Consequences
+
+### Positive consequences
+- Imported agents declare the platform capabilities their role needs, with no operator
+  hand-editing.
+- One registry and one role rule; the "no SKILL.md for built-ins" invariant has a single
+  enforcement point (`OrgPlan.skill_slugs`).
+- Closure checks stay honest — they still catch a genuinely dangling custom skill, while
+  accepting instance-provided built-ins.
+
+### Negative consequences
+- The role→built-in mapping is hard-coded to the current Paperclip catalog; a new built-in
+  or a renamed slug needs a registry edit.
+- The generator now assumes these built-in slugs exist on the target instance; a
+  non-standard instance missing one would surface only at import/runtime.
+
+### Neutral consequences
+- A single-agent bundle's lone agent is the org root, so it declares the full CEO built-in
+  set even though it has no reports — consistent with "CEO = org root".
+- Built-ins inflate each agent's `skills:` list but add no bundle files.
+
+## Alternatives considered
+
+- **Generate a SKILL.md for built-ins too.** Rejected: it spends credits to produce a
+  weaker, unmaintained copy of a vetted platform skill, and would drift from the instance
+  catalog (cf. ADR-019).
+- **Attach built-ins during rendering rather than after planning.** Rejected: role
+  (CEO/lead) is an org-structure fact; computing it once at plan time, where reportsTo is
+  authoritative, keeps the rule pure and testable and lets the skills flow through the
+  existing stub → `AgentDefinition` path unchanged.
+- **Keep `para-memory-files` as an S13 marker and special-case the skills list.** Rejected:
+  the slug is now a first-class skill reference; the memory-path prose S13 targets is
+  already covered by the other markers.
+
+## References
+
+- `src/paperclip_blueprints/patterns/builtins.py` — the registry and role rule
+- `src/paperclip_blueprints/models/org_plan.py` — `skill_slugs` built-in exclusion
+- `src/paperclip_blueprints/renderers/bundle.py` — attachment in both pipelines
+- `src/paperclip_blueprints/models/output.py`, `validators/integrity.py` — closure
+- ADR-022 (object model; S13), ADR-020 (skill attachment / `desiredSkills`, parked),
+  ADR-019 (reuse ecosystem commodity skills)

--- a/src/paperclip_blueprints/models/org_plan.py
+++ b/src/paperclip_blueprints/models/org_plan.py
@@ -14,6 +14,8 @@ import re
 
 from pydantic import BaseModel, field_validator, model_validator
 
+from ..patterns.builtins import BUILTIN_SKILLS
+
 _SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 # P-PAT-3: no manager (CEO included) owns more than this many direct reports.
@@ -138,11 +140,17 @@ class OrgPlan(BaseModel):
 
     @property
     def skill_slugs(self) -> list[str]:
-        """The de-duplicated union of every agent's skills, in first-seen order."""
+        """The custom skills that need a ``SKILL.md``: the de-duplicated union of every
+        agent's skills in first-seen order, EXCLUDING built-in slugs (ADR-023).
+
+        Built-in skills are instance-provided and resolved by slug against the catalog,
+        so they never get a generated ``skills/<slug>/SKILL.md``. Excluding them here is
+        the single point that keeps them out of the skill-generation fan-out.
+        """
         seen: list[str] = []
         for a in self.agents:
             for s in a.skills:
-                if s not in seen:
+                if s not in seen and s not in BUILTIN_SKILLS:
                     seen.append(s)
         return seen
 

--- a/src/paperclip_blueprints/models/output.py
+++ b/src/paperclip_blueprints/models/output.py
@@ -14,6 +14,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from ..patterns.builtins import BUILTIN_SKILLS
 from .agent import AgentDefinition
 from .company import CompanyDefinition
 from .input import CompanyBrief
@@ -60,9 +61,11 @@ class CompanyConfig(BaseModel):
                 raise ValueError("full bundle must have at least one task")
             if self.operations is None:
                 raise ValueError("full bundle must have operations")
+            # Built-in skills (ADR-023) resolve against the instance catalog, not the
+            # bundle, so they are valid references even without a generated SKILL.md.
             skill_slugs = {s.slug for s in self.skills}
             for a in self.agents:
-                missing = set(a.skills) - skill_slugs
+                missing = set(a.skills) - skill_slugs - BUILTIN_SKILLS
                 if missing:
                     raise ValueError(
                         f"agent {a.slug!r} references skill(s) with no SKILL.md: {sorted(missing)}"

--- a/src/paperclip_blueprints/patterns/builtins.py
+++ b/src/paperclip_blueprints/patterns/builtins.py
@@ -1,0 +1,92 @@
+"""Built-in Paperclip skills attached to agents by role (ADR-023).
+
+Every Paperclip instance ships a catalog of built-in skills that a company already
+has — they are resolved by slug against the instance catalog, NOT synthesized into
+the bundle. So a generated agent must *declare* the role-appropriate built-ins in its
+skill list (they surface in the agent's ``skills:`` frontmatter and, once skill
+attachment is wired, in ``.paperclip.yaml`` ``desiredSkills``), but the generator must
+NOT emit a ``skills/<slug>/SKILL.md`` for them and the closure check must treat their
+slugs as resolvable without one.
+
+Role rule (ADR-023):
+
+* **All agents** — ``paperclip`` (control plane: tasks, coordination, governance) and
+  ``para-memory-files`` (durable cross-wake memory).
+* **CEO + any lead** (an agent with ≥1 direct report) — also
+  ``paperclip-converting-plans-to-tasks``.
+* **CEO only** (org root / ``role: ceo``) — also ``paperclip-create-agent``.
+* **Never auto-attached** — ``paperclip-board`` (the human board member's skill) and
+  ``paperclip-dev`` (operator / instance ops). They are still recognized as built-ins
+  (so a hand-authored reference resolves without a SKILL.md), just never added here.
+
+This module is the single source of truth for both the catalog and the rule; it is a
+leaf (no runtime imports from the package) so ``models`` may import ``BUILTIN_SKILLS``
+without a cycle.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # type-only; never executed, so no import cycle with models.org_plan
+    from ..models.org_plan import AgentStub
+
+# Built-in slugs attached to every agent.
+BUILTIN_ALL: tuple[str, ...] = ("paperclip", "para-memory-files")
+
+# Added for the CEO and any lead (an agent with at least one direct report).
+BUILTIN_LEAD: tuple[str, ...] = ("paperclip-converting-plans-to-tasks",)
+
+# Added for the CEO (org root) only.
+BUILTIN_CEO: tuple[str, ...] = ("paperclip-create-agent",)
+
+# Recognized built-ins the generator never auto-attaches: the human board member's
+# skill and operator/instance-ops skill.
+BUILTIN_NEVER: frozenset[str] = frozenset({"paperclip-board", "paperclip-dev"})
+
+# Every built-in slug the generator recognizes as instance-provided. A slug in this set
+# resolves against the instance catalog, so it is valid in an agent's skill list WITHOUT
+# a bundle ``skills/<slug>/SKILL.md``, and must be excluded from SKILL.md generation.
+BUILTIN_SKILLS: frozenset[str] = frozenset(
+    {*BUILTIN_ALL, *BUILTIN_LEAD, *BUILTIN_CEO, *BUILTIN_NEVER}
+)
+
+
+def builtin_skills_for(*, is_ceo: bool, is_lead: bool) -> list[str]:
+    """Return the built-in skill slugs a role should declare, in canonical order.
+
+    Args:
+        is_ceo: The agent is the org root / ``role: ceo``.
+        is_lead: The agent has at least one direct report.
+
+    Returns:
+        The ordered built-in slugs for the role (``BUILTIN_ALL`` for everyone, plus the
+        lead/CEO tiers as they apply). Never includes a ``BUILTIN_NEVER`` slug.
+    """
+    slugs: list[str] = [*BUILTIN_ALL]
+    if is_ceo or is_lead:
+        slugs += BUILTIN_LEAD
+    if is_ceo:
+        slugs += BUILTIN_CEO
+    return slugs
+
+
+def attach_builtin_skills(agents: list[AgentStub]) -> list[AgentStub]:
+    """Append each agent's role-appropriate built-in skills to its skill list, de-duped.
+
+    Pure over the planned org: the CEO is the single root (``reports_to is None``); a
+    lead is any agent that some other agent reports to. Built-ins are appended AFTER the
+    agent's existing (custom) skills so ``skills[0]`` stays the primary custom skill, and
+    a built-in already present (e.g. listed by the org planner) is not added twice.
+
+    Mutates each stub's ``skills`` in place and returns the same list for chaining.
+    """
+    lead_slugs = {a.reports_to for a in agents if a.reports_to is not None}
+    for agent in agents:
+        additions = builtin_skills_for(
+            is_ceo=agent.reports_to is None,
+            is_lead=agent.slug in lead_slugs,
+        )
+        existing = set(agent.skills)
+        agent.skills = [*agent.skills, *(s for s in additions if s not in existing)]
+    return agents

--- a/src/paperclip_blueprints/renderers/bundle.py
+++ b/src/paperclip_blueprints/renderers/bundle.py
@@ -28,6 +28,7 @@ from ..generators.tasks import generate_task
 from ..models.input import CompanyBrief
 from ..models.output import CompanyConfig
 from ..patterns import get_seed
+from ..patterns.builtins import BUILTIN_SKILLS, attach_builtin_skills
 from ..validators import BundleValidationError, validate_bundle
 from .render import render_files
 
@@ -61,6 +62,9 @@ def generate_bundle(
     company = generate_identity(brief, client, model=model)
     emit("→ Generating agent...")
     stub = generate_org(brief, company, client, model=model)
+    # Attach role-appropriate built-in skills (ADR-023). The lone agent is the org root
+    # (CEO), so it declares the full built-in set; the custom skill stays at skills[0].
+    attach_builtin_skills([stub])
     soul = generate_soul(stub, company, client, model=model)
     agent = generate_agent(stub, company, brief, soul, client, single_agent=True, model=model)
     skill = generate_skill(stub.skills[0], company, [agent.name], client, model=model)
@@ -97,6 +101,11 @@ async def _gather_full(
         seed=seed.render() if seed is not None else None,
         model=model,
     )
+    # Attach role-appropriate built-in skills to each planned agent (ADR-023), now that
+    # reportsTo (and thus CEO/lead roles) is fixed. Done BEFORE the fan-out so each
+    # agent's AGENTS.md declares them; built-ins are excluded from skill_slugs, so no
+    # SKILL.md is generated for them.
+    attach_builtin_skills(plan.agents)
 
     sem = asyncio.Semaphore(_CONCURRENCY)
 
@@ -301,7 +310,9 @@ def _check_full(files: dict[str, str]) -> None:
         m = re.search(r"^skills:\s*\[(.*?)\]", fm, re.MULTILINE)
         if m:
             referenced |= {s.strip() for s in m.group(1).split(",") if s.strip()}
-    dangling = referenced - skill_slugs
+    # Built-in skills (ADR-023) resolve against the instance catalog, not the bundle, so
+    # they are valid references without a SKILL.md.
+    dangling = referenced - skill_slugs - BUILTIN_SKILLS
     if dangling:
         raise BundleError(f"agents reference skills with no SKILL.md: {sorted(dangling)}")
     orphan = skill_slugs - referenced

--- a/src/paperclip_blueprints/validators/integrity.py
+++ b/src/paperclip_blueprints/validators/integrity.py
@@ -15,6 +15,7 @@ from ruamel.yaml import YAML
 from ..models.org_plan import SPAN_OF_CONTROL
 from ..models.output import CompanyConfig
 from ..paperclip_slug import slugify_project_name
+from ..patterns.builtins import BUILTIN_SKILLS
 
 # Reserved human-principal role-words (ADR-016): an agent name/title must not collide
 # with the human founder/board, who sit above the company as its approver and are
@@ -96,7 +97,9 @@ def check_integrity(config: CompanyConfig, files: dict[str, str]) -> list[str]:
     for a in agents:
         for s in a.skills:
             referenced.add(s)
-            if s not in skill_set:
+            # Built-in skills (ADR-023) resolve against the instance catalog, not the
+            # bundle, so a reference to one is valid without a SKILL.md.
+            if s not in skill_set and s not in BUILTIN_SKILLS:
                 v.append(f"I5: agent {a.slug!r} references skill {s!r} with no SKILL.md")
     for s in sorted(skill_set - referenced):
         v.append(f"I5: skill {s!r} is referenced by no agent")

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -20,7 +20,11 @@ _BODY_ONLY_TOP = ("README.md", "OPERATIONS.md", "PROJECT-INVENTORY.md", "LICENSE
 # S13 (ADR-022): filesystem-read markers an agent file must never carry — a UI-imported
 # company is database-backed with no company-root tree, so the constitution/governance must
 # reach agents via the instruction bundle, never as files.
-_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>", "para-memory-files")
+# NOTE (ADR-023): `para-memory-files` was previously a marker (it named the pre-010 prose
+# that assumed a company-root memory tree). It is now a legitimate built-in skill slug an
+# agent declares in its `skills:` list, so it is no longer a marker; the memory-path prose
+# is still caught by the `Own memory` / `memory/<date>` markers.
+_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>")
 
 _OPERATIONS_HEADINGS = (
     "## Phase model",

--- a/tests/test_builtin_skills.py
+++ b/tests/test_builtin_skills.py
@@ -1,0 +1,138 @@
+"""Built-in-skills-by-role registry and attachment (ADR-023).
+
+Covers the pure role rule (`builtin_skills_for` / `attach_builtin_skills`), the
+`OrgPlan.skill_slugs` exclusion of built-ins, and an end-to-end assertion (mocked
+pipeline) that built-ins reach agent skill lists, no `skills/<builtin>/SKILL.md` is
+generated, a worker does not get the CEO-only built-in, and the bundle validates.
+"""
+
+from __future__ import annotations
+
+from paperclip_blueprints.generators.client import LLMClient
+from paperclip_blueprints.models.org_plan import AgentStub, OrgPlan
+from paperclip_blueprints.patterns.builtins import (
+    BUILTIN_SKILLS,
+    attach_builtin_skills,
+    builtin_skills_for,
+)
+from paperclip_blueprints.renderers.bundle import generate_bundle_full
+from paperclip_blueprints.renderers.render import render_files
+from paperclip_blueprints.validators import validate_bundle
+from test_cli import _dispatch_full
+from test_orchestration import _brief
+
+# --- Pure role rule ----------------------------------------------------------
+
+
+def test_every_agent_gets_paperclip_and_para_memory() -> None:
+    for is_ceo in (True, False):
+        for is_lead in (True, False):
+            got = builtin_skills_for(is_ceo=is_ceo, is_lead=is_lead)
+            assert "paperclip" in got
+            assert "para-memory-files" in got
+
+
+def test_lead_gets_converting_plans_to_tasks() -> None:
+    assert "paperclip-converting-plans-to-tasks" in builtin_skills_for(is_ceo=False, is_lead=True)
+
+
+def test_ceo_gets_converting_plans_and_create_agent() -> None:
+    got = builtin_skills_for(is_ceo=True, is_lead=False)
+    assert "paperclip-converting-plans-to-tasks" in got  # CEO is always a lead
+    assert "paperclip-create-agent" in got
+
+
+def test_worker_gets_neither_lead_nor_ceo_builtins() -> None:
+    got = builtin_skills_for(is_ceo=False, is_lead=False)
+    assert "paperclip-converting-plans-to-tasks" not in got
+    assert "paperclip-create-agent" not in got
+
+
+def test_board_and_dev_are_never_returned() -> None:
+    for is_ceo in (True, False):
+        for is_lead in (True, False):
+            got = builtin_skills_for(is_ceo=is_ceo, is_lead=is_lead)
+            assert "paperclip-board" not in got
+            assert "paperclip-dev" not in got
+
+
+# --- attach over a planned org -----------------------------------------------
+
+
+def _stub(slug: str, reports_to: str | None, skills: list[str]) -> AgentStub:
+    return AgentStub(slug=slug, name=slug.upper(), title=slug, reports_to=reports_to, skills=skills)
+
+
+def test_attach_assigns_by_role_across_the_org() -> None:
+    agents = [
+        _stub("ceo", None, ["strategy"]),
+        _stub("lead", "ceo", ["planning"]),  # has a report -> lead
+        _stub("worker", "lead", ["coding"]),  # no reports -> worker
+    ]
+    attach_builtin_skills(agents)
+    by_slug = {a.slug: a.skills for a in agents}
+
+    # everyone
+    for skills in by_slug.values():
+        assert "paperclip" in skills
+        assert "para-memory-files" in skills
+    # lead tier
+    assert "paperclip-converting-plans-to-tasks" in by_slug["ceo"]
+    assert "paperclip-converting-plans-to-tasks" in by_slug["lead"]
+    assert "paperclip-converting-plans-to-tasks" not in by_slug["worker"]
+    # CEO only
+    assert "paperclip-create-agent" in by_slug["ceo"]
+    assert "paperclip-create-agent" not in by_slug["lead"]
+    assert "paperclip-create-agent" not in by_slug["worker"]
+    # never
+    for skills in by_slug.values():
+        assert "paperclip-board" not in skills
+        assert "paperclip-dev" not in skills
+
+
+def test_attach_keeps_custom_skill_first_and_dedupes() -> None:
+    # The org planner already listed a built-in — it must not be doubled, and the
+    # custom skill must stay at index 0 (the single-agent path reads skills[0]).
+    agents = [_stub("ceo", None, ["strategy", "paperclip"])]
+    attach_builtin_skills(agents)
+    skills = agents[0].skills
+    assert skills[0] == "strategy"
+    assert skills.count("paperclip") == 1
+
+
+def test_orgplan_skill_slugs_excludes_builtins() -> None:
+    plan = OrgPlan(
+        agents=[
+            _stub("ceo", None, ["strategy", "paperclip"]),
+            _stub("worker", "ceo", ["coding", "para-memory-files"]),
+        ]
+    )
+    slugs = plan.skill_slugs
+    assert slugs == ["strategy", "coding"]  # built-ins dropped, custom order preserved
+    assert not (set(slugs) & BUILTIN_SKILLS)
+
+
+# --- End-to-end through the mocked full pipeline -----------------------------
+
+
+def test_full_bundle_attaches_builtins_without_generating_skill_md() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    skills_by_slug = {a.slug: a.skills for a in config.agents}
+
+    # ceo is root + lead (engineer reports to it); engineer is a worker.
+    ceo = skills_by_slug["ceo"]
+    engineer = skills_by_slug["engineer"]
+    for who in (ceo, engineer):
+        assert "paperclip" in who and "para-memory-files" in who
+    assert "paperclip-converting-plans-to-tasks" in ceo
+    assert "paperclip-create-agent" in ceo
+    assert "paperclip-create-agent" not in engineer  # worker never gets create-agent
+
+    # No SKILL.md is generated for any built-in; only custom skills get a file.
+    files = render_files(config)
+    for slug in BUILTIN_SKILLS:
+        assert f"skills/{slug}/SKILL.md" not in files
+    assert {s.slug for s in config.skills} == {"release-checklist"}
+
+    # The closure/validation treats built-ins as valid even without a SKILL.md.
+    validate_bundle(config, files)  # must not raise

--- a/tests/test_object_model_constitution.py
+++ b/tests/test_object_model_constitution.py
@@ -14,7 +14,9 @@ from paperclip_blueprints.validators.schema_shape import _check_idle_state, chec
 from test_models import _full_config_kwargs
 from test_templates import _config
 
-_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>", "para-memory-files")
+# `para-memory-files` dropped from the marker set in ADR-023 — it is now a legitimate
+# built-in skill slug, not filesystem-read prose (still caught by the memory-path markers).
+_FS_MARKERS = ("## File system", "Company root", "Own memory", "memory/<date>")
 
 
 # --- US2: no filesystem-read assumptions; HEARTBEAT empty --------------------


### PR DESCRIPTION
## What

Generated agents only referenced the custom skills the tool synthesizes, so an imported agent had no handle on the platform's **built-in** skills that every company already has in its catalog. This declares the role-appropriate built-ins in each agent's skill list, resolved by slug against the instance catalog.

## Role → built-in mapping (single source: `patterns/builtins.py`)

- **All agents:** `paperclip` (control plane — tasks, coordination, governance) and `para-memory-files` (durable cross-wake memory).
- **CEO + any lead** (an agent with ≥1 direct report): also `paperclip-converting-plans-to-tasks`.
- **CEO only** (org root / `role: ceo`): also `paperclip-create-agent`.
- **Never auto-attached:** `paperclip-board` (human board member's skill) and `paperclip-dev` (operator/instance ops) — still recognized as built-ins so a hand-authored reference resolves without a SKILL.md.

`attach_builtin_skills()` runs after the org is planned (reportsTo — and thus CEO/lead roles — fixed) and custom skills are assigned. Built-ins are appended **after** the custom skills (so `skills[0]` stays the primary custom skill) and de-duped.

## No SKILL.md for built-ins

Built-ins are instance-provided and resolved by slug, so they get **no** generated `SKILL.md`. The single exclusion point is `OrgPlan.skill_slugs` (the set driving skill-generation fan-out), which now filters out `BUILTIN_SKILLS` — so no `skills/<builtin>/` directory is ever created. Every skill-closure check treats a built-in slug as valid without a bundle file: the `CompanyConfig` model validator, the `I5` integrity check, and the legacy `structural_check`.

The built-ins reach the deployer via each agent's `AGENTS.md` `skills:` frontmatter (where agent skills already live), so no other wiring is needed.

## S13 marker cleanup

`para-memory-files` was listed as an S13 filesystem-read marker (ADR-022) — it named the pre-010 prose that assumed a company-root memory tree. It is now a legitimate skill slug, so it is removed from the marker set; the memory-path prose S13 guards against is still caught by the `Own memory` / `memory/<date>` markers.

## Notes

- A **single-agent** bundle's lone agent is the org root → CEO, so it declares the full CEO built-in set even with no reports. Consistent with "CEO = org root"; intended behavior.

## Known live-verification follow-up (not a generator issue)

Once a regenerated bundle carries built-ins, the deployer's skill-sync will send bare slugs (`paperclip`, `para-memory-files`, …) that have no SKILL.md, so they must resolve against the instance's built-in catalog. On 2026.626.0 these are globally available and should resolve. If a sync instead 404s with `unknown reference: paperclip`, that is a small skill-sync **reference-format** fix on the deployer side — not a change to this generator.

## ADR

`docs/adr/023-builtin-skills-by-role.md` records the role mapping, the no-SKILL.md rule, and the S13 marker change.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest 318 passed, 2 skipped (+9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)