### PR TITLE
F2: reasoned goal hierarchy (emit side)

### DIFF
--- a/docs/adr/025-reasoned-goal-hierarchy.md
+++ b/docs/adr/025-reasoned-goal-hierarchy.md
@@ -1,0 +1,120 @@
+# ADR-025: Emit a reasoned goal hierarchy (structured goals with per-agent owners)
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-05
+
+## Context
+
+The generator emits company goals as a flat list of strings (COMPANY.md frontmatter
+`goals:`). A deployer reading that can only create the goals flat, all at company level and
+all CEO-owned. But a well-formed agent company is a **north-star → sub-goals tree with
+per-agent owners**: the single north star is the company's root outcome, and each goal is
+an outcome some specific agent is accountable for.
+
+Generation is the only stage that knows **both** the north star (from identity) **and**
+which agent owns which outcome (from the org it just designed), so building the hierarchy
+is a generation responsibility — and it must be **reasoned** from the org graph, not
+mechanical. The deployer's native-Goal API (documented as D4 in the local gap reference)
+takes exactly `title`, `description`, `level`, `parentId`, `ownerAgentId`; the generator
+should emit goals in that shape so the deployer can create a real tree.
+
+An ordering wrinkle makes this non-trivial: identity generation (which produces the goals)
+runs **first**, before any agent exists, so goals cannot be owned at that point. Owner
+reasoning needs `AgentDefinition.mandate`, which only exists after the per-agent fan-out.
+
+## Decision
+
+### Reasoning model
+
+- The brief's single **north star → the root goal**, owned by the org root (CEO), at
+  company level.
+- Each **brief goal → a sub-goal** nested under the north star, owned by the agent whose
+  mandate makes it accountable for that outcome (reasoned from the org just designed), at
+  agent (or team) level.
+- A goal stays **company-level / CEO-owned only** where it is genuinely cross-cutting with
+  no single accountable agent, or the company is too small for role separation. The rule is
+  "nest with reasoned ownership; default company-level only when no single agent owns it,"
+  not "always nest."
+- **Single-agent company:** the lone agent is root/CEO; goals stay company-level owned by
+  it, nested under the root — no orphan, no second root.
+
+### Ordering
+
+The goal-hierarchy step is a new **post-fan-out** step, sequenced alongside
+`generate_operations` (which already runs last because it needs the agent list). It runs
+after the agents are generated so it can read their mandates. It is sequenced **before**
+operations so operations remains the final call (it echoes the whole company). The LLM
+decides only *owner* + *level* per goal; the tree shape (single root, each goal nested under
+it) is built **deterministically** in the generator, and a deterministic fallback
+(north-star → root; anything ambiguous or a single-agent company → company-level/CEO) means
+a flaky or absent model can never yield an orphan or a second root. A single-agent company
+skips the LLM entirely.
+
+### Carrier
+
+Emit the structured hierarchy as an **additive block in COMPANY.md frontmatter under
+`metadata.paperclip.goalHierarchy`**, and **preserve the flat `goals:` list** for
+backward-compat. Each entry carries `slug` (the goal id → deployer `parentId`/self),
+`title`, `description`, `level`, `parent` (parent goal slug → `parentId`, `null` for root),
+`owner` (agent slug → `ownerAgentId`). The structured form is primary/additive; a bundle
+with only the flat list still validates.
+
+### Validators (hard failures)
+
+Per "LLM creativity can't overrule structural rules," a malformed hierarchy is rejected, not
+silently passed: `GoalHierarchy` enforces exactly one root, unique slugs, resolvable and
+acyclic parents; `CompanyConfig` and the bundle validator (`I14`) additionally require every
+`owner` to resolve to a real agent in the org. The flat form continues to validate on its
+own.
+
+## Consequences
+
+### Positive consequences
+- The deployer can create a real goal tree with per-agent owners instead of a flat,
+  all-CEO list — this is the generator-side prerequisite for native-Goal creation (D4).
+- Ownership is reasoned from the org the generator actually designed, at the one stage that
+  knows both the north star and the mandates.
+- The tree is structurally valid by construction; the model only influences owner/level, so
+  a bad or missing call degrades gracefully rather than corrupting the bundle.
+
+### Negative consequences
+- One more Sonnet call per full multi-agent generation (skipped for single-agent).
+- Owner assignment is best-effort reasoning; a mis-assignment is possible but always a
+  *valid* owner (validated), never a structural break.
+
+### Neutral consequences
+- `title`/`description` are currently derived from the goal text (deterministic); richer
+  per-goal copy could be generated later without changing the carrier.
+- COMPANY.md goals do not survive Paperclip import (ADR-022); the structured block is read by
+  the deployer, which reconciles it into native Goals — this ADR is the emit side only.
+
+## Alternatives considered
+
+- **Carrier: a dedicated file (e.g. `GOALS.md`).** Rejected: adds a file to the bundle
+  contract and a second place company data lives; goals are company identity and belong with
+  COMPANY.md, which the deployer already parses.
+- **Carrier: a `.paperclip.yaml` block.** Rejected: `.paperclip.yaml` is the runtime/import
+  config (sidebar, agents, projects, routines); company goal *content* is identity, not
+  runtime config, and COMPANY.md frontmatter is where such structured company data already
+  lives.
+- **Reason ownership during identity generation (keep it one step).** Rejected: impossible —
+  the org does not exist yet, so there is no agent to own a goal and no mandate to reason
+  from. The step must run after the fan-out.
+- **Let the LLM emit the whole tree (parents included).** Rejected: it could produce two
+  roots or dangling parents. Building the tree deterministically and having the LLM decide
+  only owner/level removes that failure mode.
+
+## References
+
+- `src/paperclip_blueprints/models/goal.py` — `GoalDefinition` + `GoalHierarchy`
+- `src/paperclip_blueprints/generators/goal_hierarchy.py`,
+  `prompts/goal_hierarchy_generator.md` — the reasoning step + fallback
+- `src/paperclip_blueprints/renderers/render.py` — the `metadata.paperclip.goalHierarchy` carrier
+- `src/paperclip_blueprints/models/output.py`, `validators/integrity.py` (`I14`) — owner closure
+- ADR-022 (goals don't survive import; carried for the deployer), local gap reference D4
+  (native-Goal API field set)

--- a/src/paperclip_blueprints/generators/goal_hierarchy.py
+++ b/src/paperclip_blueprints/generators/goal_hierarchy.py
@@ -1,0 +1,163 @@
+"""goal_hierarchy_generator — reason the north-star → sub-goals tree (Sonnet, ADR-025).
+
+Runs AFTER the per-agent fan-out (alongside operations) because owner reasoning needs each
+``AgentDefinition.mandate`` — which only exists once agents are generated. The LLM decides
+only *owner* + *level* per goal; the tree shape (single root = north star, every goal
+nested under it) is built deterministically here, so a flaky or absent model can never
+produce an orphan or a second root. Unknown/ambiguous owners fall back to the org root at
+company level, and a single-agent company skips the LLM entirely (the lone agent owns
+everything).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..config import STRUCTURAL_MODEL
+from ..models.agent import AgentDefinition
+from ..models.company import CompanyDefinition
+from ..models.goal import GoalDefinition, GoalHierarchy, GoalLevel
+from ..models.input import CompanyBrief
+from ..paperclip_slug import dedupe_slug, slugify_project_name
+from .client import GenerationError, LLMClient, render_prompt
+
+_SYSTEM = "You assign ownership for Paperclip company goals. Follow the instructions exactly."
+_ROOT_SLUG = "north-star"
+
+# Raw structured-output schema: one {owner, level} per goal, in order.
+_ASSIGN_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "additionalProperties": False,
+    "required": ["assignments"],
+    "properties": {
+        "assignments": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["owner", "level"],
+                "properties": {
+                    "owner": {"type": "string"},
+                    "level": {"type": "string", "enum": ["company", "team", "agent"]},
+                },
+            },
+        }
+    },
+}
+
+
+def _org_root(agents: list[AgentDefinition]) -> AgentDefinition:
+    """The single org-root agent (the CEO); ``reports_to is None``."""
+    return next(a for a in agents if a.reports_to is None)
+
+
+def _assignments(
+    company: CompanyDefinition,
+    brief: CompanyBrief,
+    agents: list[AgentDefinition],
+    client: LLMClient,
+    *,
+    model: str | None,
+) -> list[dict[str, str]] | None:
+    """Ask the model for one ``{owner, level}`` per goal, or ``None`` to fall back.
+
+    Returns ``None`` — signalling the deterministic company-level/CEO default — for a
+    single-agent company (no reasoning needed) or when the call fails or returns the wrong
+    number of assignments. Never raises: a goal hierarchy must always be produced.
+    """
+    if len(agents) < 2:
+        return None
+    prompt = render_prompt(
+        "goal_hierarchy_generator",
+        north_star=company.north_star,
+        goals=company.goals,
+        agents=agents,
+    )
+    try:
+        payload = client.complete_json(
+            model=model or STRUCTURAL_MODEL,
+            system=_SYSTEM,
+            user=prompt,
+            what="goal hierarchy",
+            schema=_ASSIGN_SCHEMA,
+        )
+    except GenerationError:
+        return None
+    assignments = payload.get("assignments")
+    if not isinstance(assignments, list) or len(assignments) != len(company.goals):
+        return None
+    return assignments
+
+
+def _resolve_owner(
+    assignment: dict[str, str] | None,
+    agent_slugs: set[str],
+    root_slug: str,
+) -> tuple[str, GoalLevel]:
+    """Resolve one goal's ``(owner, level)``, coercing anything unusable to CEO/company.
+
+    A goal stays company-level/CEO-owned when the assignment is absent (fallback /
+    single-agent), names ``"company"``, or names an owner not in the org.
+    """
+    if assignment is None:
+        return root_slug, "company"
+    owner = assignment.get("owner", "")
+    level = assignment.get("level", "")
+    if owner not in agent_slugs:  # "company" or a hallucinated slug
+        return root_slug, "company"
+    resolved_level: GoalLevel = "team" if level == "team" else "agent"
+    return owner, resolved_level
+
+
+def generate_goal_hierarchy(
+    company: CompanyDefinition,
+    brief: CompanyBrief,
+    agents: list[AgentDefinition],
+    client: LLMClient,
+    *,
+    model: str | None = None,
+) -> GoalHierarchy:
+    """Build the reasoned north-star → sub-goals tree for a company.
+
+    Args:
+        company: The identity content (north star + flat goals).
+        brief: The operator's brief (carried for symmetry with the other generators).
+        agents: The generated agents, WITH mandates — the owner-reasoning input.
+        client: The LLM client (Sonnet call for multi-agent owner assignment).
+        model: Optional model override.
+
+    Returns:
+        A validated ``GoalHierarchy``: one root (the north star, owned by the org root),
+        each brief goal nested under it with a reasoned owner and level. Structurally valid
+        by construction; the LLM never controls the tree shape, only owner/level.
+    """
+    root_agent = _org_root(agents)
+    agent_slugs = {a.slug for a in agents}
+    root = GoalDefinition(
+        slug=_ROOT_SLUG,
+        title="North star",
+        description=company.north_star,
+        level="company",
+        parent=None,
+        owner=root_agent.slug,
+    )
+
+    assignments = _assignments(company, brief, agents, client, model=model)
+    used = {_ROOT_SLUG}
+    children: list[GoalDefinition] = []
+    for i, goal in enumerate(company.goals):
+        assignment = assignments[i] if assignments is not None else None
+        owner, level = _resolve_owner(assignment, agent_slugs, root_agent.slug)
+        slug = dedupe_slug(slugify_project_name(goal) or f"goal-{i + 1}", used)
+        children.append(
+            GoalDefinition(
+                slug=slug,
+                title=goal,
+                description=goal,
+                level=level,
+                parent=_ROOT_SLUG,
+                owner=owner,
+            )
+        )
+
+    return GoalHierarchy(goals=[root, *children])

--- a/src/paperclip_blueprints/models/goal.py
+++ b/src/paperclip_blueprints/models/goal.py
@@ -1,0 +1,102 @@
+"""GoalDefinition + GoalHierarchy — the reasoned north-star → sub-goals tree (ADR-025).
+
+A company's goals form a hierarchy, not a flat list: the brief's single north star is
+the root, each brief goal is a sub-goal owned by the agent whose mandate makes it
+accountable for that outcome, and a goal stays company-level/CEO-owned only where it is
+genuinely cross-cutting (no single accountable agent) or the company is too small for role
+separation. The field set (``title``/``description``/``level``/``parent``/``owner`` plus a
+stable ``slug`` id) matches the deployer's native-Goal API (``title``/``description``/
+``level``/``parentId``/``ownerAgentId``): ``slug`` → the Goal id, ``parent`` → ``parentId``
+(the parent goal's slug), ``owner`` → ``ownerAgentId`` (the owning agent's slug).
+
+Structural invariants (exactly one root, resolvable/acyclic parents, unique slugs) are
+enforced here on ``GoalHierarchy``; owner-resolves-to-a-real-agent needs the org and is
+enforced by ``CompanyConfig`` and the bundle validator.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, field_validator, model_validator
+
+GoalLevel = Literal["company", "team", "agent"]
+
+_SLUG_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+
+
+class GoalDefinition(BaseModel):
+    """One goal in the hierarchy, shaped for the deployer's native-Goal fields."""
+
+    slug: str
+    """Stable goal id (maps to the deployer's Goal id; referenced by children's ``parent``)."""
+    title: str
+    description: str
+    level: GoalLevel
+    parent: str | None
+    """Parent goal's ``slug`` (maps to ``parentId``); ``None`` for the single root goal."""
+    owner: str
+    """Owning agent's ``slug`` (maps to ``ownerAgentId``)."""
+
+    @field_validator("slug")
+    @classmethod
+    def _slug_shape(cls, v: str) -> str:
+        if not _SLUG_RE.match(v):
+            raise ValueError(f"goal slug must be lowercase-hyphenated: {v!r}")
+        return v
+
+    @field_validator("title", "description", "owner")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError("must not be empty")
+        return v.strip()
+
+
+class GoalHierarchy(BaseModel):
+    """The full north-star → sub-goals tree for a company.
+
+    Enforces the tree invariants that do not need the org graph: exactly one root
+    (``parent is None``), unique slugs, every ``parent`` resolving to a goal in the set,
+    and acyclicity. Owner-resolves-to-a-real-agent is enforced where the agents are known
+    (``CompanyConfig`` / the bundle validator), not here.
+    """
+
+    goals: list[GoalDefinition]
+
+    @model_validator(mode="after")
+    def _check_tree(self) -> GoalHierarchy:
+        if not self.goals:
+            raise ValueError("a goal hierarchy must contain at least the root goal")
+
+        slugs = [g.slug for g in self.goals]
+        dupes = {s for s in slugs if slugs.count(s) > 1}
+        if dupes:
+            raise ValueError(f"duplicate goal slug(s): {sorted(dupes)}")
+        slug_set = set(slugs)
+
+        roots = [g.slug for g in self.goals if g.parent is None]
+        if len(roots) != 1:
+            raise ValueError(f"goal hierarchy must have exactly one root goal; found {roots}")
+
+        for g in self.goals:
+            if g.parent is not None and g.parent not in slug_set:
+                raise ValueError(f"goal {g.slug!r} has unknown parent {g.parent!r}")
+
+        parent = {g.slug: g.parent for g in self.goals}
+        for start in parent:
+            seen = {start}
+            cur = parent[start]
+            while cur is not None:
+                if cur in seen:
+                    raise ValueError(f"goal hierarchy has a cycle through {cur!r}")
+                seen.add(cur)
+                cur = parent.get(cur)
+
+        return self
+
+    @property
+    def root(self) -> GoalDefinition:
+        """The single root goal (the north star)."""
+        return next(g for g in self.goals if g.parent is None)

--- a/src/paperclip_blueprints/models/output.py
+++ b/src/paperclip_blueprints/models/output.py
@@ -17,6 +17,7 @@ from pydantic import BaseModel, Field, model_validator
 from ..patterns.builtins import BUILTIN_SKILLS
 from .agent import AgentDefinition
 from .company import CompanyDefinition
+from .goal import GoalHierarchy
 from .input import CompanyBrief
 from .operations import OperationsDefinition
 from .project import ProjectDefinition
@@ -35,6 +36,10 @@ class CompanyConfig(BaseModel):
     projects: list[ProjectDefinition] = Field(default_factory=list)
     tasks: list[TaskDefinition] = Field(default_factory=list)
     operations: OperationsDefinition | None = None
+    goal_hierarchy: GoalHierarchy | None = None
+    """The reasoned north-star → sub-goals tree (ADR-025). Additive and optional: a bundle
+    may carry only the flat ``company.goals`` list (backward-compat), but when present every
+    goal's ``owner`` must resolve to a real agent in the org."""
     license_kind: str = "Proprietary"
 
     @model_validator(mode="after")
@@ -69,5 +74,15 @@ class CompanyConfig(BaseModel):
                 if missing:
                     raise ValueError(
                         f"agent {a.slug!r} references skill(s) with no SKILL.md: {sorted(missing)}"
+                    )
+        # Goal-hierarchy owner closure (ADR-025): the tree's structural invariants are
+        # enforced on GoalHierarchy; here — where the org is known — every goal owner must
+        # resolve to a real agent. Applies in either mode when a hierarchy is present.
+        if self.goal_hierarchy is not None:
+            agent_slugs = {a.slug for a in self.agents}
+            for goal in self.goal_hierarchy.goals:
+                if goal.owner not in agent_slugs:
+                    raise ValueError(
+                        f"goal {goal.slug!r} owner {goal.owner!r} is not an agent in the org"
                     )
         return self

--- a/src/paperclip_blueprints/prompts/goal_hierarchy_generator.md
+++ b/src/paperclip_blueprints/prompts/goal_hierarchy_generator.md
@@ -1,0 +1,50 @@
+You assign ownership for a Paperclip company's goals. The company's single north star is
+the root goal; each goal below reports up to it. Your job is to decide, for EACH goal, the
+one agent accountable for that outcome and the level at which it sits.
+
+## The north star (the root goal — already owned by the org root)
+
+{{ north_star }}
+
+## The goals to assign (in order)
+
+{% for g in goals %}
+{{ loop.index }}. {{ g }}
+{% endfor %}
+
+## The agents (owner candidates) and their mandates
+
+{% for a in agents %}
+- `{{ a.slug }}` — {{ a.title }}: {{ a.mandate }}
+{% endfor %}
+
+## How to decide
+
+For each goal, pick the ONE agent whose mandate makes it accountable for that outcome, and
+set the level:
+
+- **`level: "agent"`** — a single agent owns the outcome. Set `owner` to that agent's slug.
+- **`level: "team"`** — a manager owns the outcome on behalf of the agents reporting to it.
+  Set `owner` to the manager's slug.
+- **`level: "company"`** — the goal is genuinely cross-cutting with NO single accountable
+  agent (or the company is too small for role separation). Set `owner` to `"company"`.
+
+Rules:
+
+- Nest with reasoned ownership. Default to `"company"` ONLY when no single agent owns the
+  outcome — do NOT push everything to company level, and do NOT invent an owner where the
+  mandates do not support one.
+- `owner` MUST be one of the agent slugs listed above, or the literal `"company"`.
+- Return EXACTLY one assignment per goal, in the SAME ORDER as the goals above.
+
+## Output format
+
+Return ONE fenced ```json block and nothing else:
+
+```json
+{
+  "assignments": [
+    {"owner": "<agent-slug or 'company'>", "level": "agent | team | company"}
+  ]
+}
+```

--- a/src/paperclip_blueprints/renderers/bundle.py
+++ b/src/paperclip_blueprints/renderers/bundle.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ..generators.agents import generate_agent
 from ..generators.client import GenerationError, LLMClient
+from ..generators.goal_hierarchy import generate_goal_hierarchy
 from ..generators.identity import generate_identity
 from ..generators.operations import generate_operations
 from ..generators.org import AgentStub, generate_org, generate_org_plan
@@ -68,8 +69,16 @@ def generate_bundle(
     soul = generate_soul(stub, company, client, model=model)
     agent = generate_agent(stub, company, brief, soul, client, single_agent=True, model=model)
     skill = generate_skill(stub.skills[0], company, [agent.name], client, model=model)
+    # The lone agent is the org root/CEO; the hierarchy degrades deterministically (no LLM
+    # call) to that agent owning the north star and every goal at company level (ADR-025).
+    goal_hierarchy = generate_goal_hierarchy(company, brief, [agent], client, model=model)
     return CompanyConfig(
-        mode="single", brief=brief, company=company, agents=[agent], skills=[skill]
+        mode="single",
+        brief=brief,
+        company=company,
+        agents=[agent],
+        skills=[skill],
+        goal_hierarchy=goal_hierarchy,
     )
 
 
@@ -172,6 +181,14 @@ async def _gather_full(
         ),
     )
 
+    # The goal hierarchy and operations both run after the fan-out — they need the generated
+    # agents (the hierarchy for mandate-based owner reasoning, ADR-025; operations for routine
+    # slots). Sequenced so operations stays the last call (it echoes the whole company).
+    agent_defs = list(agents)
+    emit("→ Reasoning goal hierarchy...")
+    goal_hierarchy = await asyncio.to_thread(
+        generate_goal_hierarchy, company, brief, agent_defs, client, model=model
+    )
     emit("→ Writing operations...")
     operations = await asyncio.to_thread(
         generate_operations, company, brief, plan.agents, client, model=model
@@ -182,11 +199,12 @@ async def _gather_full(
             mode="full",
             brief=brief,
             company=company,
-            agents=list(agents),
+            agents=agent_defs,
             skills=list(skills),
             projects=list(projects),
             tasks=list(tasks),
             operations=operations,
+            goal_hierarchy=goal_hierarchy,
         )
     except Exception as exc:  # noqa: BLE001 - pydantic ValidationError surfaces cleanly
         raise GenerationError(f"assembled bundle failed validation: {exc}") from exc

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from pathlib import Path
+from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
 from ..models.agent import AgentDefinition
 from ..models.company import CompanyDefinition
+from ..models.goal import GoalHierarchy
 from ..models.output import CompanyConfig
 from ..models.project import ProjectDefinition
 from ..models.skill import SkillDefinition
@@ -40,12 +42,38 @@ def _render(template: str, **ctx: object) -> str:
     return _env.get_template(template).render(**ctx)
 
 
-def render_company_md(company: CompanyDefinition) -> str:
-    """Render COMPANY.md (frontmatter + body) from identity content alone.
+def render_company_md(
+    company: CompanyDefinition, goal_hierarchy: GoalHierarchy | None = None
+) -> str:
+    """Render COMPANY.md (frontmatter + body) from identity content.
 
-    Shared by the full bundle and ``blueprints preview`` (US3), which emits only
-    this file.
+    Shared by the full bundle and ``blueprints preview`` (US3), which emits only this file.
+
+    Args:
+        company: The identity content (carries the flat ``goals`` list).
+        goal_hierarchy: The reasoned north-star → sub-goals tree (ADR-025). When given, it
+            is emitted additively under ``metadata.paperclip.goalHierarchy`` for the
+            deployer; the flat ``goals`` list is always preserved for backward-compat.
+            ``None`` (e.g. ``preview``, which runs before the org exists) omits the block.
     """
+    paperclip_meta: dict[str, Any] = {
+        # `mono` is the company monogram letter, derived from the name
+        # (matches the reference companies: Newsletter→N, Agency→A, …).
+        "tone": company.tone,
+        "mono": company.name[0].upper(),
+    }
+    if goal_hierarchy is not None:
+        paperclip_meta["goalHierarchy"] = [
+            {
+                "slug": g.slug,
+                "title": g.title,
+                "description": g.description,
+                "level": g.level,
+                "parent": g.parent,
+                "owner": g.owner,
+            }
+            for g in goal_hierarchy.goals
+        ]
     frontmatter = dump_frontmatter(
         {
             "schema": "agentcompanies/v1",
@@ -55,9 +83,7 @@ def render_company_md(company: CompanyDefinition) -> str:
             "tags": company.tags,
             "goals": company.goals,
             "metadata": {
-                # `mono` is the company monogram letter, derived from the name
-                # (matches the reference companies: Newsletter→N, Agency→A, …).
-                "paperclip": {"tone": company.tone, "mono": company.name[0].upper()},
+                "paperclip": paperclip_meta,
                 "sources": [{"kind": "url"}],
             },
         },
@@ -285,7 +311,7 @@ def render_files(
 
     files: dict[str, str] = {
         ".paperclip.yaml": _render("paperclip_yaml.j2", **base),
-        "COMPANY.md": render_company_md(config.company),
+        "COMPANY.md": render_company_md(config.company, config.goal_hierarchy),
         "README.md": _render("readme_md.j2", **base),
         "LICENSE.txt": _render("license_txt.j2", **base),
     }

--- a/src/paperclip_blueprints/validators/integrity.py
+++ b/src/paperclip_blueprints/validators/integrity.py
@@ -150,6 +150,22 @@ def check_integrity(config: CompanyConfig, files: dict[str, str]) -> list[str]:
                     f"Founder/Board"
                 )
 
+    # I14: goal-hierarchy closure (ADR-025). Structural invariants (one root, resolvable/
+    # acyclic parents, unique slugs) are guaranteed by the GoalHierarchy model; here we
+    # re-assert them plus owner-resolves-to-a-real-agent on the assembled bundle, so a
+    # malformed hierarchy is a hard failure in the aggregated report, not a silent pass.
+    if config.goal_hierarchy is not None:
+        goals = config.goal_hierarchy.goals
+        goal_slugs = {g.slug for g in goals}
+        roots = [g.slug for g in goals if g.parent is None]
+        if len(roots) != 1:
+            v.append(f"I14: goal hierarchy must have exactly one root, found {sorted(roots)}")
+        for g in goals:
+            if g.parent is not None and g.parent not in goal_slugs:
+                v.append(f"I14: goal {g.slug!r} has unknown parent {g.parent!r}")
+            if g.owner not in agent_slugs:
+                v.append(f"I14: goal {g.slug!r} owner {g.owner!r} is not an agent in the org")
+
     # I10: file set matches the mode contract exactly.
     expected = _expected_files(config)
     actual = set(files)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -123,6 +123,13 @@ _TASK = """```json
  "completion_criteria": ["Build uploads to the store", "Smoke pass is green"]}
 ```"""
 
+# Goal-hierarchy owner assignment (ADR-025): one {owner, level} per company goal, in order.
+# _IDENTITY carries two goals; assign one to the engineer and keep one cross-cutting.
+_GOAL_ASSIGN = """```json
+{"assignments": [{"owner": "engineer", "level": "agent"},
+                 {"owner": "company", "level": "company"}]}
+```"""
+
 
 def _dispatch_full(**kwargs: object) -> str:
     system = str(kwargs["system"]).lower()
@@ -134,6 +141,8 @@ def _dispatch_full(**kwargs: object) -> str:
         return _SOUL
     if "mandate" in system:
         return _AGENT
+    if "ownership" in system:  # goal-hierarchy owner assignment
+        return _GOAL_ASSIGN
     if "operations" in system:
         return _OPERATIONS
     if "project" in system:

--- a/tests/test_goal_hierarchy.py
+++ b/tests/test_goal_hierarchy.py
@@ -1,0 +1,326 @@
+"""Reasoned goal hierarchy (ADR-025) — model invariants + the reasoning generator.
+
+Covers the north-star → sub-goals tree: exactly one root, resolvable parents, per-agent
+owners reasoned from mandates, cross-cutting goals kept company-level, single-agent
+degradation, and the deterministic fallback that a flaky/absent LLM never yields an orphan
+or a second root.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from paperclip_blueprints.generators.client import GenerationError, LLMClient
+from paperclip_blueprints.generators.goal_hierarchy import generate_goal_hierarchy
+from paperclip_blueprints.models.agent import AgentDefinition
+from paperclip_blueprints.models.company import CompanyDefinition
+from paperclip_blueprints.models.goal import GoalDefinition, GoalHierarchy, GoalLevel
+from paperclip_blueprints.models.input import CompanyBrief
+from test_models import _agent_kwargs, _brief_kwargs, _company_kwargs
+
+# --- GoalHierarchy model invariants ------------------------------------------
+
+
+def _goal(slug: str, parent: str | None, owner: str, level: GoalLevel = "agent") -> GoalDefinition:
+    return GoalDefinition(
+        slug=slug,
+        title=slug,
+        description=f"{slug} outcome",
+        level=level,
+        parent=parent,
+        owner=owner,
+    )
+
+
+def test_hierarchy_accepts_one_root_with_resolvable_parents() -> None:
+    h = GoalHierarchy(
+        goals=[
+            _goal("north-star", None, "ceo", "company"),
+            _goal("rating", "north-star", "qa"),
+        ]
+    )
+    assert h.root.slug == "north-star"
+
+
+def test_hierarchy_rejects_two_roots() -> None:
+    with pytest.raises(ValueError, match="exactly one root"):
+        GoalHierarchy(
+            goals=[
+                _goal("north-star", None, "ceo", "company"),
+                _goal("other-root", None, "ceo", "company"),
+            ]
+        )
+
+
+def test_hierarchy_rejects_dangling_parent() -> None:
+    with pytest.raises(ValueError, match="unknown parent"):
+        GoalHierarchy(
+            goals=[_goal("north-star", None, "ceo", "company"), _goal("x", "missing", "qa")]
+        )
+
+
+def test_hierarchy_rejects_duplicate_slugs() -> None:
+    with pytest.raises(ValueError, match="duplicate goal slug"):
+        GoalHierarchy(
+            goals=[
+                _goal("north-star", None, "ceo", "company"),
+                _goal("north-star", "north-star", "qa"),
+            ]
+        )
+
+
+# --- generate_goal_hierarchy: multi-agent reasoning --------------------------
+
+
+def _company(**overrides: Any) -> CompanyDefinition:
+    return CompanyDefinition(**{**_company_kwargs(), **overrides})
+
+
+def _brief() -> CompanyBrief:
+    return CompanyBrief(**_brief_kwargs())
+
+
+def _agents() -> list[AgentDefinition]:
+    ceo = AgentDefinition(**_agent_kwargs(slug="ceo", name="CEO", title="CEO", reports_to=None))
+    qa = AgentDefinition(
+        **_agent_kwargs(
+            slug="qa",
+            name="QA Lead",
+            title="QA Lead",
+            reports_to="ceo",
+            skills=["release-checklist"],
+            mandate="Owns product quality and the store rating.",
+        )
+    )
+    return [ceo, qa]
+
+
+def _assign_transport(assignments: list[dict[str, str]]):
+    import json
+
+    def _t(**_: object) -> str:
+        return "```json\n" + json.dumps({"assignments": assignments}) + "\n```"
+
+    return _t
+
+
+def test_north_star_is_the_root_owned_by_org_root() -> None:
+    company = _company(
+        goals=["Maintain a 4.6+ rating", "Keep refund rate below 3%"],
+        north_star="$30k monthly net revenue within 12 months.",
+    )
+    h = generate_goal_hierarchy(
+        company,
+        _brief(),
+        _agents(),
+        LLMClient(_invoke=_assign_transport([{"owner": "qa", "level": "agent"}] * 2)),
+    )
+    assert h.root.parent is None
+    assert h.root.owner == "ceo"  # org root
+    assert company.north_star in h.root.description
+    assert h.root.level == "company"
+
+
+def test_each_goal_is_nested_and_owned_by_the_reasoned_agent() -> None:
+    company = _company(goals=["Maintain a 4.6+ rating", "Keep refund rate below 3%"])
+    h = generate_goal_hierarchy(
+        company,
+        _brief(),
+        _agents(),
+        LLMClient(
+            _invoke=_assign_transport(
+                [{"owner": "qa", "level": "agent"}, {"owner": "qa", "level": "agent"}]
+            )
+        ),
+    )
+    subs = [g for g in h.goals if g.parent is not None]
+    assert len(subs) == 2
+    for g in subs:
+        assert g.parent == h.root.slug
+        assert g.owner == "qa"
+        assert g.level == "agent"
+
+
+def test_cross_cutting_goal_stays_company_level_ceo_owned() -> None:
+    company = _company(goals=["Maintain a 4.6+ rating", "Uphold the brand across all work"])
+    h = generate_goal_hierarchy(
+        company,
+        _brief(),
+        _agents(),
+        LLMClient(
+            _invoke=_assign_transport(
+                [{"owner": "qa", "level": "agent"}, {"owner": "company", "level": "company"}]
+            )
+        ),
+    )
+    by_owner = {g.description: (g.owner, g.level) for g in h.goals if g.parent is not None}
+    assert by_owner["Uphold the brand across all work"] == ("ceo", "company")
+
+
+def test_unknown_owner_is_coerced_to_ceo_company_level() -> None:
+    company = _company(goals=["Maintain a 4.6+ rating"])
+    h = generate_goal_hierarchy(
+        company,
+        _brief(),
+        _agents(),
+        LLMClient(_invoke=_assign_transport([{"owner": "ghost", "level": "agent"}])),
+    )
+    sub = next(g for g in h.goals if g.parent is not None)
+    assert sub.owner == "ceo" and sub.level == "company"
+
+
+# --- single-agent degradation + fallback -------------------------------------
+
+
+def _solo_agent() -> list[AgentDefinition]:
+    return [AgentDefinition(**_agent_kwargs(slug="ceo", name="CEO", title="CEO", reports_to=None))]
+
+
+def test_single_agent_company_degrades_to_lone_root_no_orphan() -> None:
+    calls = {"n": 0}
+
+    def _boom(**_: object) -> str:
+        calls["n"] += 1
+        raise AssertionError("no LLM call should be made for a single-agent company")
+
+    company = _company(goals=["Maintain a 4.6+ rating", "Keep refund rate below 3%"])
+    h = generate_goal_hierarchy(company, _brief(), _solo_agent(), LLMClient(_invoke=_boom))
+    assert calls["n"] == 0  # deterministic: no owner reasoning needed
+    assert h.root.owner == "ceo"
+    for g in h.goals:
+        assert g.owner == "ceo"
+        if g.parent is not None:
+            assert g.parent == h.root.slug  # nested, not orphaned
+
+
+def test_fallback_when_llm_fails_yields_single_root_all_ceo() -> None:
+    def _fail(**_: object) -> str:
+        raise GenerationError("model unavailable")
+
+    company = _company(goals=["Maintain a 4.6+ rating", "Keep refund rate below 3%"])
+    h = generate_goal_hierarchy(company, _brief(), _agents(), LLMClient(_invoke=_fail))
+    assert len([g for g in h.goals if g.parent is None]) == 1  # exactly one root
+    assert all(g.owner == "ceo" for g in h.goals)  # every goal owned by the CEO/root
+    assert all(g.level == "company" for g in h.goals)
+
+
+# --- CompanyConfig owner-closure + backward-compat ---------------------------
+
+
+def test_company_config_accepts_a_valid_goal_hierarchy() -> None:
+    from paperclip_blueprints.models.output import CompanyConfig
+    from test_models import _full_config_kwargs
+
+    kwargs = _full_config_kwargs()  # agents: ceo, cto
+    kwargs["goal_hierarchy"] = GoalHierarchy(
+        goals=[
+            _goal("north-star", None, "ceo", "company"),
+            _goal("arch", "north-star", "cto", "agent"),
+        ]
+    )
+    config = CompanyConfig(**kwargs)
+    assert config.goal_hierarchy is not None
+
+
+def test_company_config_rejects_goal_owner_not_in_org() -> None:
+    from paperclip_blueprints.models.output import CompanyConfig
+    from test_models import _full_config_kwargs
+
+    kwargs = _full_config_kwargs()
+    kwargs["goal_hierarchy"] = GoalHierarchy(
+        goals=[
+            _goal("north-star", None, "ceo", "company"),
+            _goal("arch", "north-star", "ghost", "agent"),  # unknown owner
+        ]
+    )
+    with pytest.raises(ValueError, match="owner"):
+        CompanyConfig(**kwargs)
+
+
+def test_backward_compat_flat_only_bundle_still_validates() -> None:
+    from paperclip_blueprints.models.output import CompanyConfig
+    from test_models import _full_config_kwargs
+
+    config = CompanyConfig(**_full_config_kwargs())  # no goal_hierarchy at all
+    assert config.goal_hierarchy is None  # the flat goals: list remains the carrier
+
+
+# --- carrier: COMPANY.md frontmatter metadata.paperclip.goalHierarchy --------
+
+
+def test_company_md_carries_structured_hierarchy_and_keeps_flat_goals() -> None:
+    from ruamel.yaml import YAML
+
+    from paperclip_blueprints.renderers.render import render_company_md
+
+    company = _company(goals=["Maintain a 4.6+ rating"], north_star="$30k MRR in 12 months.")
+    hierarchy = GoalHierarchy(
+        goals=[
+            _goal("north-star", None, "ceo", "company"),
+            _goal("rating", "north-star", "qa", "agent"),
+        ]
+    )
+    out = render_company_md(company, hierarchy)
+    fm = YAML(typ="safe").load(out.split("---\n", 2)[1])
+    # flat goals: preserved for backward-compat
+    assert fm["goals"] == ["Maintain a 4.6+ rating"]
+    # structured hierarchy is additive under metadata.paperclip
+    gh = fm["metadata"]["paperclip"]["goalHierarchy"]
+    assert [g["slug"] for g in gh] == ["north-star", "rating"]
+    rating = next(g for g in gh if g["slug"] == "rating")
+    assert rating["owner"] == "qa"
+    assert rating["parent"] == "north-star"
+    assert rating["level"] == "agent"
+    root = next(g for g in gh if g["slug"] == "north-star")
+    assert root["parent"] is None
+
+
+def test_company_md_omits_hierarchy_when_absent() -> None:
+    from ruamel.yaml import YAML
+
+    from paperclip_blueprints.renderers.render import render_company_md
+
+    out = render_company_md(_company())  # no hierarchy (e.g. `preview`)
+    fm = YAML(typ="safe").load(out.split("---\n", 2)[1])
+    assert "goalHierarchy" not in fm["metadata"]["paperclip"]
+    assert "goals" in fm  # flat list still present
+
+
+# --- bundle validator (hard failure) -----------------------------------------
+
+
+def _full_config_with_hierarchy(goals: list[GoalDefinition]):
+    from paperclip_blueprints.models.output import CompanyConfig
+    from test_models import _full_config_kwargs
+
+    kwargs = _full_config_kwargs()
+    kwargs["goal_hierarchy"] = GoalHierarchy(goals=goals)
+    return CompanyConfig(**kwargs)
+
+
+def test_bundle_validator_clean_on_a_valid_hierarchy() -> None:
+    from paperclip_blueprints.renderers.render import render_files
+    from paperclip_blueprints.validators.integrity import check_integrity
+
+    config = _full_config_with_hierarchy(
+        [_goal("north-star", None, "ceo", "company"), _goal("arch", "north-star", "cto", "agent")]
+    )
+    files = render_files(config)
+    assert not [v for v in check_integrity(config, files) if v.startswith("I14")]
+
+
+def test_bundle_validator_flags_goal_owner_not_in_org() -> None:
+    from paperclip_blueprints.renderers.render import render_files
+    from paperclip_blueprints.validators.integrity import check_integrity
+
+    # Bypass the CompanyConfig owner-closure to reach the validator: build a valid config,
+    # then mutate a goal owner to an unknown slug on the already-constructed object.
+    config = _full_config_with_hierarchy(
+        [_goal("north-star", None, "ceo", "company"), _goal("arch", "north-star", "cto", "agent")]
+    )
+    assert config.goal_hierarchy is not None
+    config.goal_hierarchy.goals[1].owner = "ghost"
+    files = render_files(config)
+    assert any(v.startswith("I14") and "ghost" in v for v in check_integrity(config, files))


### PR DESCRIPTION
## What

The generator emitted company goals as a flat list of strings (COMPANY.md frontmatter `goals:`), so a deployer could only create them flat, company-level, all CEO-owned. A well-formed agent company is a **north-star → sub-goals tree with per-agent owners**, and generation is the only stage that knows both the north star and which agent owns which outcome — so the hierarchy is a generation responsibility, reasoned from the org graph.

**Emit side only** — the D4 deployer/consumer lives elsewhere and reads this. The change is additive: a flat-list bundle still works.

## Reasoning model

- North star → **root goal**, owned by the org root (CEO), company level.
- Each brief goal → a **sub-goal** nested under the north star, owned by the agent whose **mandate** makes it accountable, at agent/team level.
- Company-level/CEO **only** where genuinely cross-cutting (no single accountable agent) or the company is too small for role separation — "nest with reasoned ownership; default company-level only when no single agent owns it," not "always nest."
- Single-agent company → the lone agent is root/CEO, no orphan nesting.

## Ordering (the crux)

Identity generation runs first, before the org exists, so goals can't be owned there — owner reasoning needs `AgentDefinition.mandate`. The goal-hierarchy step is therefore a new **post-fan-out** step, sequenced before `generate_operations` so operations stays the last call. The LLM decides **only owner + level per goal**; the tree shape is built deterministically, with a fallback (ambiguous / absent LLM / single-agent → company-level/CEO) so a flaky model never yields an orphan or a second root. Single-agent skips the LLM entirely.

## Changes

- **`models/goal.py`** — `GoalDefinition` (`slug` id + `title`/`description`/`level`/`parent`/`owner`, matching the deployer's native-Goal `title`/`description`/`level`/`parentId`/`ownerAgentId`) and `GoalHierarchy` (one root, unique slugs, resolvable + acyclic parents).
- **`generators/goal_hierarchy.py` + `prompts/goal_hierarchy_generator.md`** — the Sonnet reasoning step + deterministic fallback.
- **`renderers/render.py`** — additive `metadata.paperclip.goalHierarchy` block in COMPANY.md frontmatter; the flat `goals:` list is preserved (backward-compat).
- **`renderers/bundle.py`** — wires the step into the full and single-agent pipelines.
- **`models/output.py` + `validators/integrity.py` (`I14`)** — hard-failure owner closure: every goal owner must resolve to a real agent.

## Carrier decision

Structured hierarchy under **COMPANY.md frontmatter `metadata.paperclip.goalHierarchy`**, flat `goals:` preserved. Alternatives (dedicated file, `.paperclip.yaml` block) documented and rejected in ADR-025 — frontmatter is where company structured data already lives and the deployer already parses it.

## Tests (+17)

Model invariants; north-star→root; each goal→reasoned agent nested; cross-cutting→company-level; unknown owner coerced; single-agent degradation (asserts no LLM call); fallback path; CompanyConfig owner-closure; `I14` hard-fail; carrier round-trip; backward-compat flat-only.

## ADR

`docs/adr/025-reasoned-goal-hierarchy.md` — reasoning model, ordering rationale, carrier decision + rejected alternatives.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest 341 passed, 2 skipped (+17 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)