### PR TITLE
F3: per-agent capability carrier (emit side)

### DIFF
--- a/docs/adr/026-per-agent-capability-carrier.md
+++ b/docs/adr/026-per-agent-capability-carrier.md
@@ -1,0 +1,93 @@
+# ADR-026: Emit a structured per-agent capability set
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-05
+
+## Context
+
+A generated bundle carries no structured per-agent capability signal. The deployer's
+per-agent capability step (D7 in the local gap reference) applies only explicitly-declared
+capabilities and deliberately does not force-derive them from prose or role — so with the
+bundle silent, D7 is a no-op for every agent. But some roles genuinely need a platform
+capability their role requires: a scanner/research role needs read-only web access to fetch
+external pages; a CEO or editor does not. Generation is where the role and mandate are
+known, so deriving that capability set is a generation responsibility, and the bundle should
+carry it in a structured form D7 already knows how to consume.
+
+A capability grant is a permission decision, so the derivation must not over-grant. That
+rules out a free-reasoning LLM (which could hand out capabilities a role does not need) and
+argues for a conservative, auditable rule.
+
+## Decision
+
+### Derivation (deterministic, conservative)
+
+Add `derive_capabilities(role, title, mandate)` in `patterns/capabilities.py` — a
+**deterministic** keyword-reasoned mapping over the agent's role/title/mandate, applied to
+the generated agents after the per-agent fan-out (where the mandate exists), via
+`attach_capabilities`. A role/title/mandate that signals external web-information gathering
+(whole-word signals: `web`, `scan`/`scanner`, `research`, `prospect`, `discover`,
+`source`/`sourcing`, `scrape`, `crawl`, `online`, `url`, …) is granted `web-fetch`
+(read-only external web access). Everything else gets nothing.
+
+Conservative by default: grant only what the role genuinely needs, no blanket capabilities,
+and when in doubt grant nothing (an empty set → D7 no-op for that agent). Word-boundary
+matching keeps `resource`/`outsource` from tripping `source`. Choosing a rule over an LLM
+applies the project's "LLM creativity can't overrule structural rules" principle to access
+control — the grant is inspectable and stable, not model-dependent.
+
+### Carrier
+
+Emit the set as a structured **`capabilities:` list in each agent's AGENTS.md frontmatter**,
+alongside `skills:` — the same per-agent frontmatter the deployer already parses (the skill
+list travels there too). The field is a flow sequence (`[web-fetch]`, or `[]` when none).
+`AgentDefinition.capabilities` defaults to empty, so the change is additive and a bundle
+without it still validates; each entry must be a known capability slug
+(`KNOWN_CAPABILITIES`), rejected otherwise.
+
+## Consequences
+
+### Positive consequences
+- D7 has a real per-agent capability signal to act on; a scanner role deploys with the web
+  access it needs, without the operator hand-granting it.
+- Grants are conservative and auditable — a keyword rule, not an LLM, so no over-grant and
+  no per-agent LLM cost.
+- Additive and backward-compatible: existing bundles/agents keep working with an empty set.
+
+### Negative consequences
+- The role→capability mapping and the capability vocabulary are hard-coded; a new capability
+  or signal needs a code edit.
+- Keyword derivation can miss a role that phrases its web need unusually (false negative) —
+  acceptable, since the conservative bias is deliberate and the operator can still grant
+  explicitly.
+
+### Neutral consequences
+- Only `web-fetch` is derived today; the registry (`KNOWN_CAPABILITIES`) is open for more.
+- `capabilities: []` now renders on every agent's AGENTS.md — explicit and consistent for
+  the deployer, at the cost of one extra frontmatter line per agent.
+
+## Alternatives considered
+
+- **Derive capabilities with an LLM reasoning step.** Rejected: a permission grant must not
+  be model-improvised; an LLM risks over-granting, which is exactly what "conservative, when
+  in doubt omit" forbids. A deterministic rule is auditable and stable.
+- **Carry capabilities in a `.paperclip.yaml` per-agent block.** Rejected: per-agent
+  structured signals (skills) already live in AGENTS.md frontmatter, which the deployer
+  parses; keeping capabilities next to skills is consistent and avoids splitting per-agent
+  data across two files.
+- **Grant a broad default capability set.** Rejected: blanket capabilities violate least
+  privilege; grant only what the role genuinely needs.
+
+## References
+
+- `src/paperclip_blueprints/patterns/capabilities.py` — the registry + derivation
+- `src/paperclip_blueprints/models/agent.py` — the `capabilities` field + known-slug validator
+- `src/paperclip_blueprints/renderers/render.py` — the AGENTS.md frontmatter carrier
+- `src/paperclip_blueprints/renderers/bundle.py` — attachment in both pipelines
+- local gap reference D7 (per-agent tool/capability API), ADR-023 (built-in skills; the
+  analogous per-agent, deterministic, leaf-module pattern)

--- a/src/paperclip_blueprints/models/agent.py
+++ b/src/paperclip_blueprints/models/agent.py
@@ -6,7 +6,7 @@ TOOLS.md is rendered deterministically from the agent's slug, the company slug, 
 
 from __future__ import annotations
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class AgentSoul(BaseModel):
@@ -47,6 +47,10 @@ class AgentDefinition(BaseModel):
     derive from reports_to and verify additional role values against the
     importer enum before emitting them."""
     skills: list[str]
+    capabilities: list[str] = Field(default_factory=list)
+    """Structured per-agent platform capabilities the deployer (D7) grants (ADR-026),
+    e.g. ``web-fetch`` (read-only external web access). Derived conservatively from the
+    role/mandate; empty by default (D7 no-op). Additive: a bundle without it still validates."""
     mandate: str
     triggers: list[str]
     receives_from: list[str]
@@ -63,4 +67,19 @@ class AgentDefinition(BaseModel):
     def _at_least_one_skill(cls, v: list[str]) -> list[str]:
         if not v:
             raise ValueError("an agent must reference at least one skill")
+        return v
+
+    @field_validator("capabilities")
+    @classmethod
+    def _known_capabilities(cls, v: list[str]) -> list[str]:
+        # Each capability must be one the deployer knows how to grant (ADR-026).
+        # Imported locally so the model stays loadable without importing the patterns
+        # package at module load.
+        from ..patterns.capabilities import KNOWN_CAPABILITIES
+
+        unknown = [c for c in v if c not in KNOWN_CAPABILITIES]
+        if unknown:
+            raise ValueError(
+                f"unknown capability slug(s): {unknown}; known: {sorted(KNOWN_CAPABILITIES)}"
+            )
         return v

--- a/src/paperclip_blueprints/patterns/capabilities.py
+++ b/src/paperclip_blueprints/patterns/capabilities.py
@@ -1,0 +1,80 @@
+"""Per-agent capability derivation (ADR-026).
+
+A Paperclip agent may need a platform capability its role genuinely requires — e.g. a
+scanner/research role needs read-only web access to fetch external pages. The bundle
+carries no structured capability signal today, so the deployer's per-agent capability step
+(D7) has nothing to act on. This module derives a conservative, structured capability set
+per agent from its role/title/mandate, which D7 consumes.
+
+Capability grants are a permission decision, so the derivation is **deterministic and
+auditable** — a keyword-reasoned mapping over role/title/mandate — NOT an LLM call that
+could over-grant (the "LLM creativity can't overrule structural rules" principle applied to
+access). It is conservative by default: grant only what the role genuinely needs, and when
+in doubt grant nothing (D7 stays a no-op for that agent).
+
+This is a leaf module (no runtime imports from the package) so ``models`` may import
+``KNOWN_CAPABILITIES`` without a cycle.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # type-only; never executed, so no import cycle with models.agent
+    from ..models.agent import AgentDefinition
+
+# The read-only web-fetch capability: fetch external web pages (reading only). The single
+# capability the generator derives today; the set is open for future additions.
+WEB_FETCH = "web-fetch"
+
+# Every capability slug the generator recognizes. A per-agent ``capabilities`` entry must be
+# one of these; the deployer resolves them against its per-agent capability API.
+KNOWN_CAPABILITIES: frozenset[str] = frozenset({WEB_FETCH})
+
+# Whole-word signals in an agent's role/title/mandate that a role genuinely gathers external
+# web information (→ read-only web-fetch). Word-boundary matched, so "resource"/"outsource"
+# do not trip "source". Kept tight to avoid over-granting.
+_WEB_FETCH_RE = re.compile(
+    r"\b("
+    r"web|internet|online|urls?|scrape|scraping|crawl|crawling|"
+    r"scan|scanner|scanning|research|researching|prospect|prospecting|"
+    r"discover|discovery|sources?|sourcing"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def derive_capabilities(*, role: str | None, title: str, mandate: str) -> list[str]:
+    """Return the capability slugs an agent's role genuinely needs, sorted and de-duped.
+
+    Conservative: only a role/title/mandate that signals external web-information gathering
+    is granted ``web-fetch``; everything else gets nothing (an empty list → D7 no-op).
+
+    Args:
+        role: The agent's importer role (may be ``None``).
+        title: The agent's title.
+        mandate: The agent's mandate prose (AGENTS.md).
+
+    Returns:
+        A sorted list of granted capability slugs (all in ``KNOWN_CAPABILITIES``), possibly
+        empty.
+    """
+    text = " ".join(filter(None, (role, title, mandate)))
+    granted: set[str] = set()
+    if _WEB_FETCH_RE.search(text):
+        granted.add(WEB_FETCH)
+    return sorted(granted)
+
+
+def attach_capabilities(agents: list[AgentDefinition]) -> list[AgentDefinition]:
+    """Set each agent's ``capabilities`` from its role/title/mandate (ADR-026).
+
+    Mutates each agent in place and returns the same list for chaining. Runs after the
+    per-agent fan-out, where the mandate exists.
+    """
+    for agent in agents:
+        agent.capabilities = derive_capabilities(
+            role=agent.role, title=agent.title, mandate=agent.mandate
+        )
+    return agents

--- a/src/paperclip_blueprints/renderers/bundle.py
+++ b/src/paperclip_blueprints/renderers/bundle.py
@@ -30,6 +30,7 @@ from ..models.input import CompanyBrief
 from ..models.output import CompanyConfig
 from ..patterns import get_seed
 from ..patterns.builtins import BUILTIN_SKILLS, attach_builtin_skills
+from ..patterns.capabilities import attach_capabilities
 from ..validators import BundleValidationError, validate_bundle
 from .render import render_files
 
@@ -68,6 +69,7 @@ def generate_bundle(
     attach_builtin_skills([stub])
     soul = generate_soul(stub, company, client, model=model)
     agent = generate_agent(stub, company, brief, soul, client, single_agent=True, model=model)
+    attach_capabilities([agent])  # derive capabilities from the lone agent's role/mandate (ADR-026)
     skill = generate_skill(stub.skills[0], company, [agent.name], client, model=model)
     # The lone agent is the org root/CEO; the hierarchy degrades deterministically (no LLM
     # call) to that agent owning the north star and every goal at company level (ADR-025).
@@ -181,10 +183,13 @@ async def _gather_full(
         ),
     )
 
+    # Derive each agent's structured capabilities from its role/mandate (ADR-026), now that
+    # the mandates exist. Deterministic and conservative; empty for roles with no need.
+    agent_defs = attach_capabilities(list(agents))
+
     # The goal hierarchy and operations both run after the fan-out — they need the generated
     # agents (the hierarchy for mandate-based owner reasoning, ADR-025; operations for routine
     # slots). Sequenced so operations stays the last call (it echoes the whole company).
-    agent_defs = list(agents)
     emit("→ Reasoning goal hierarchy...")
     goal_hierarchy = await asyncio.to_thread(
         generate_goal_hierarchy, company, brief, agent_defs, client, model=model

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -101,8 +101,9 @@ def _agent_frontmatter(agent: AgentDefinition) -> str:
             "title": agent.title,
             "reportsTo": agent.reports_to,
             "skills": agent.skills,
+            "capabilities": agent.capabilities,
         },
-        flow_seq_keys={"skills"},
+        flow_seq_keys={"skills", "capabilities"},
     )
 
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,117 @@
+"""Per-agent capability derivation and carrier (ADR-026).
+
+Covers the deterministic, conservative role/mandate → capability mapping (scanner/research
+→ read-only web-fetch; a role with no special need → none), the model's known-capability
+validation, the AGENTS.md frontmatter carrier, and the end-to-end pipeline attachment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from paperclip_blueprints.generators.client import LLMClient
+from paperclip_blueprints.models.agent import AgentDefinition
+from paperclip_blueprints.patterns.capabilities import (
+    WEB_FETCH,
+    attach_capabilities,
+    derive_capabilities,
+)
+from paperclip_blueprints.renderers.bundle import generate_bundle_full
+from paperclip_blueprints.renderers.render import render_files
+from test_cli import _dispatch_full
+from test_models import _agent_kwargs
+from test_orchestration import _brief
+
+# --- pure derivation ---------------------------------------------------------
+
+
+def test_scanner_role_gets_web_fetch() -> None:
+    caps = derive_capabilities(
+        role=None,
+        title="Market Scanner",
+        mandate="Scan external sources and fetch web pages for early signals.",
+    )
+    assert caps == [WEB_FETCH]
+
+
+def test_research_role_gets_web_fetch() -> None:
+    caps = derive_capabilities(
+        role=None, title="Research Analyst", mandate="Research online trends every week."
+    )
+    assert caps == [WEB_FETCH]
+
+
+def test_role_with_no_web_need_gets_nothing() -> None:
+    assert derive_capabilities(
+        role="ceo", title="CEO", mandate="Owns the north star and ships the title."
+    ) == []
+    assert derive_capabilities(
+        role=None, title="Editor", mandate="Edit and polish drafts before publication."
+    ) == []
+
+
+def test_derivation_is_word_boundaried_not_substring() -> None:
+    # "resource"/"outsource" contain "source" but must NOT trip the web-fetch grant.
+    assert derive_capabilities(
+        role=None, title="Ops Lead", mandate="Allocate resources and outsource nothing."
+    ) == []
+
+
+# --- attach + model validation -----------------------------------------------
+
+
+def test_attach_sets_capabilities_by_role() -> None:
+    scanner = AgentDefinition(
+        **_agent_kwargs(
+            slug="scanner",
+            name="Scanner",
+            title="Scanner",
+            reports_to="ceo",
+            mandate="Scan the web for leads.",
+        )
+    )
+    editor = AgentDefinition(
+        **_agent_kwargs(
+            slug="editor", name="Editor", title="Editor", reports_to="ceo", mandate="Polish copy."
+        )
+    )
+    attach_capabilities([scanner, editor])
+    assert scanner.capabilities == [WEB_FETCH]
+    assert editor.capabilities == []
+
+
+def test_model_rejects_unknown_capability() -> None:
+    with pytest.raises(ValueError, match="unknown capability"):
+        AgentDefinition(**_agent_kwargs(capabilities=["root-shell"]))
+
+
+def test_capabilities_default_empty_backward_compat() -> None:
+    agent = AgentDefinition(**_agent_kwargs())  # no capabilities passed
+    assert agent.capabilities == []
+
+
+# --- carrier: AGENTS.md frontmatter ------------------------------------------
+
+
+def test_agents_md_frontmatter_carries_capabilities() -> None:
+    from ruamel.yaml import YAML
+
+    from test_templates import _config
+
+    config = _config()
+    config.agents[0].capabilities = [WEB_FETCH]
+    fm = render_files(config)["agents/ceo/AGENTS.md"].split("---\n", 2)[1]
+    assert YAML(typ="safe").load(fm)["capabilities"] == [WEB_FETCH]
+
+
+# --- end-to-end pipeline attachment ------------------------------------------
+
+
+def test_full_pipeline_attaches_capabilities_field_to_every_agent() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    # every agent carries the structured field; the canned CEO/engineer roles need no web
+    # access, so it is empty for them (D7 no-op) — conservative by default.
+    for agent in config.agents:
+        assert agent.capabilities == []
+    fm = render_files(config)["agents/engineer/AGENTS.md"]
+    assert "capabilities:" in fm


### PR DESCRIPTION
## What

A generated bundle carried no structured per-agent capability signal, so the deployer's per-agent capability step (D7) was a no-op — it applies only explicitly-declared capabilities and deliberately does not force-derive from prose/role. Some roles genuinely need a capability their role requires (a scanner/research role needs read-only web access); generation is where the role/mandate is known, so deriving the set is a generation responsibility.

**Emit side only** — the D7 consumer lives elsewhere and reads this. Additive: a bundle without the field still validates.

## Derivation (deterministic, conservative)

Capability grants are a permission decision, so the derivation is a **deterministic** keyword-reasoned rule over role/title/mandate — NOT an LLM that could over-grant (the "LLM creativity can't overrule structural rules" principle applied to access control). A role signalling external web-information gathering (`scan`/`scanner`, `research`, `prospect`, `discover`, `source`/`sourcing`, `web`, `scrape`, `crawl`, `online`, `url`, …) gets `web-fetch` (read-only external web access); everything else gets nothing (empty → D7 no-op). Word-boundary matched, so `resource`/`outsource` don't trip `source`. Conservative by default: no blanket capabilities; when in doubt, omit.

## Changes

- **`patterns/capabilities.py`** — `KNOWN_CAPABILITIES` + `derive_capabilities` + `attach_capabilities` (leaf module, mirrors the ADR-023 built-in-skills pattern).
- **`models/agent.py`** — additive `capabilities` field (default empty → backward-compat) + a validator rejecting any slug not in `KNOWN_CAPABILITIES`.
- **`renderers/render.py`** — carrier: `capabilities:` in AGENTS.md frontmatter alongside `skills:` (the per-agent frontmatter the deployer already parses).
- **`renderers/bundle.py`** — attach after the fan-out (mandates exist) in the full and single-agent pipelines.

## Carrier decision

`capabilities:` in **AGENTS.md frontmatter**, next to `skills:`. Alternatives (`.paperclip.yaml` per-agent block; LLM derivation; blanket grants) documented and rejected in ADR-026.

## Tests (+9)

scanner→web-fetch; research→web-fetch; CEO/editor→none; word-boundary (resource/outsource→none); attach-by-role; unknown-capability rejected; default-empty backward-compat; frontmatter carrier round-trip; end-to-end pipeline (every agent carries the field, canned roles get `[]`).

## ADR

`docs/adr/026-per-agent-capability-carrier.md` — deterministic-derivation rationale, carrier decision + rejected alternatives.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest 350 passed, 2 skipped (+9 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)