### PR TITLE
F5: bundle-configurable run caps (emit side)

### DIFF
--- a/docs/adr/027-bundle-configurable-run-caps.md
+++ b/docs/adr/027-bundle-configurable-run-caps.md
@@ -1,0 +1,95 @@
+# ADR-027: Emit bundle-configurable per-agent run-policy caps
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-05
+
+## Context
+
+The deployer sets run-policy caps as hard-coded defaults: `adapterConfig.maxTurnsPerRun = 30`
+for every agent, and `runtimeConfig.heartbeat.maxConcurrentRuns` = 1 for the CEO / 2 for
+others. Those are one-size defaults — a company cannot tune them per role. But roles differ:
+a decision-maker (CEO) wants tighter concurrency so it does not fan out parallel runs against
+itself; a bounded poller does a quick, repeated check and does not need the full turn budget
+(and capping its turns low guards against a runaway loop). Generation knows each agent's role
+and mandate, so it is the place to reason these caps and emit them into the bundle for the
+deployer to consume.
+
+## Decision
+
+Add `renderers/run_policy.py` — a pure, deterministic (no LLM) reasoning step that produces a
+`RunPolicy(max_turns_per_run, max_concurrent_runs)` per agent from its role:
+
+- **`maxConcurrentRuns`**: the CEO/org-root gets `1` (tighter); every other agent gets `2`.
+- **`maxTurnsPerRun`**: a **bounded poller** — a role whose title/mandate signals a repeated
+  bounded check (whole-word `poll`/`monitor`/`watch`/`sweep`, boundary-matched so `watchdog`
+  or `sweepstakes` do not trip it) — gets `10`; every other agent gets `30`.
+
+The defaults (`30`; CEO `1` / others `2`) **match the deployer's current hard-coded defaults**,
+so behavior is unchanged for any role the reasoning does not tighten; the reasoning only
+tightens where a role justifies it. The caps are emitted per agent in `.paperclip.yaml` under a
+`runPolicy` block:
+
+```yaml
+agents:
+  ceo:
+    runPolicy:
+      maxTurnsPerRun: 30
+      maxConcurrentRuns: 1
+```
+
+The deployer maps `runPolicy.maxTurnsPerRun → adapterConfig.maxTurnsPerRun` and
+`runPolicy.maxConcurrentRuns → runtimeConfig.heartbeat.maxConcurrentRuns`. The block is emitted
+for every agent, so the bundle is the single source of truth for the caps (a bundle that
+reproduces the defaults yields unchanged behavior; a bundle that tightens a role overrides).
+
+This is the emit side only — the deployer consumer (reading `runPolicy` instead of hard-coding)
+lives in the private repo.
+
+## Consequences
+
+### Positive consequences
+- Run caps are bundle-driven and per-role: a company tunes them by regenerating, without
+  editing the deployer.
+- Defaults match today's deployer behavior, so adopting this changes nothing until a bundle
+  actually differs.
+- Deterministic and auditable — the caps are a role rule, not model output, and are visible in
+  `.paperclip.yaml`.
+
+### Negative consequences
+- The role→cap mapping (and the poller signal set) is hard-coded; new heuristics need a code
+  edit.
+- Operator-brief-level caps are not wired yet (see below), so tuning today is via the role
+  reasoning, not a per-company brief knob.
+
+### Neutral consequences
+- Every agent now carries a `runPolicy` block in `.paperclip.yaml` — explicit and consistent
+  for the deployer, at a few extra lines per agent.
+- Only two caps are emitted today; the `RunPolicy` shape is open for more.
+
+## Alternatives considered
+
+- **Keep the caps hard-coded in the deployer.** Rejected: that is the status quo F5 removes —
+  a company cannot tune per role.
+- **Reason the caps with an LLM.** Rejected: caps are a bounded operational knob with a clear
+  role rule; a deterministic mapping is auditable and cheap, and there is no judgment an LLM
+  adds here.
+- **Emit `maxTurnsPerRun` under `adapter.config` and `maxConcurrentRuns` under a separate
+  `runtimeConfig` block (mirroring the deployer's exact nesting).** Rejected for now: it splits
+  one per-agent concern across two blocks and couples `maxTurnsPerRun` to the presence of an
+  `adapter` block. A single `runPolicy` block is cleaner and maps unambiguously; the deployer
+  does the two-field split.
+- **Add per-company/per-role caps to the operator brief.** Deferred: it touches the input
+  template and brief parsing (ADR-003). The role reasoning covers the concrete need now; a brief
+  knob can layer on top later (as ADR-017 layered explicit model preferences over role defaults).
+
+## References
+
+- `src/paperclip_blueprints/renderers/run_policy.py` — the reasoning + `RunPolicy`
+- `src/paperclip_blueprints/renderers/render.py`, `templates/paperclip_yaml.j2` — the carrier
+- ADR-012 (per-agent `budgetMonthlyCents`) and ADR-017 (per-agent adapter/model) — the
+  analogous per-agent `.paperclip.yaml` derivations this follows

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -25,6 +25,7 @@ from .adapter import assign_adapters, parse_model_preferences
 from .budget import allocate_budgets
 from .frontmatter import dump_frontmatter
 from .routines import RoutineSpec, derive_routines
+from .run_policy import assign_run_policies
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
@@ -307,6 +308,9 @@ def render_files(
         "license_kind": config.license_kind,
         "budgets": allocation.cents,
         "adapters": adapters,
+        # Per-agent run-policy caps (ADR-027): bundle-driven maxTurnsPerRun /
+        # maxConcurrentRuns reasoned from role, defaults matching the deployer's.
+        "run_policies": assign_run_policies(config.agents),
         "routines": routines,
     }
 

--- a/src/paperclip_blueprints/renderers/run_policy.py
+++ b/src/paperclip_blueprints/renderers/run_policy.py
@@ -1,0 +1,77 @@
+"""Per-agent run-policy caps (ADR-027).
+
+The deployer previously set run-policy caps as hard-coded defaults
+(``adapterConfig.maxTurnsPerRun = 30``; ``runtimeConfig.heartbeat.maxConcurrentRuns`` = 1
+for the CEO / 2 for others). This module makes them **bundle-driven**: it reasons a
+``RunPolicy`` per agent from role, so a company can tune caps per role instead of accepting
+one global default. The values are emitted into ``.paperclip.yaml`` under each agent's
+``runPolicy`` block; the deployer maps ``runPolicy.maxTurnsPerRun`` →
+``adapterConfig.maxTurnsPerRun`` and ``runPolicy.maxConcurrentRuns`` →
+``runtimeConfig.heartbeat.maxConcurrentRuns``.
+
+Pure and deterministic (no LLM). The defaults match the deployer's current hard-coded
+defaults, so behavior is unchanged for a role the reasoning does not tighten; the reasoning
+only tightens where a role justifies it (a decision-maker/CEO gets tighter concurrency; a
+bounded poller gets low turns).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..models.agent import AgentDefinition
+
+# Deployer-matching defaults: unchanged behavior unless a role tightens them.
+DEFAULT_MAX_TURNS_PER_RUN = 30
+CEO_MAX_CONCURRENT_RUNS = 1
+DEFAULT_MAX_CONCURRENT_RUNS = 2
+
+# A bounded poller does a quick, repeated, bounded check — it does not need the full turn
+# budget, so cap it low to stop a runaway loop.
+POLLER_MAX_TURNS_PER_RUN = 10
+
+# Whole-word signals that a role is a bounded poller (→ low turns). Word-boundary matched to
+# avoid tripping on unrelated substrings. Kept tight so an ordinary role keeps the default.
+_POLLER_RE = re.compile(
+    r"\b(poll|polls|polling|monitor|monitors|monitoring|watch|watches|watching|"
+    r"sweep|sweeps|sweeping)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class RunPolicy:
+    """One agent's run-policy caps, emitted under ``.paperclip.yaml`` ``runPolicy``."""
+
+    max_turns_per_run: int
+    max_concurrent_runs: int
+
+
+def derive_run_policy(*, is_root: bool, title: str, mandate: str) -> RunPolicy:
+    """Reason an agent's run-policy caps from its role.
+
+    Args:
+        is_root: The agent is the org root / CEO (``reports_to is None``).
+        title: The agent's title.
+        mandate: The agent's mandate prose.
+
+    Returns:
+        A ``RunPolicy``: the CEO/root gets tighter concurrency (1 vs 2); a bounded poller
+        gets low turns (``POLLER_MAX_TURNS_PER_RUN``); otherwise the deployer-matching
+        defaults (30 turns) apply.
+    """
+    max_concurrent = CEO_MAX_CONCURRENT_RUNS if is_root else DEFAULT_MAX_CONCURRENT_RUNS
+    is_poller = bool(_POLLER_RE.search(f"{title} {mandate}"))
+    max_turns = POLLER_MAX_TURNS_PER_RUN if is_poller else DEFAULT_MAX_TURNS_PER_RUN
+    return RunPolicy(max_turns_per_run=max_turns, max_concurrent_runs=max_concurrent)
+
+
+def assign_run_policies(agents: list[AgentDefinition]) -> dict[str, RunPolicy]:
+    """Return each agent's reasoned ``RunPolicy``, keyed by slug (ADR-027)."""
+    return {
+        a.slug: derive_run_policy(is_root=a.reports_to is None, title=a.title, mandate=a.mandate)
+        for a in agents
+    }

--- a/src/paperclip_blueprints/templates/paperclip_yaml.j2
+++ b/src/paperclip_blueprints/templates/paperclip_yaml.j2
@@ -19,6 +19,11 @@ agents:
 {% if a.slug in budgets %}
     budgetMonthlyCents: {{ budgets[a.slug] }}
 {% endif %}
+{% if a.slug in run_policies %}
+    runPolicy:
+      maxTurnsPerRun: {{ run_policies[a.slug].max_turns_per_run }}
+      maxConcurrentRuns: {{ run_policies[a.slug].max_concurrent_runs }}
+{% endif %}
 {% endfor %}
 {% if projects %}
 projects:

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -42,19 +42,28 @@ def test_research_role_gets_web_fetch() -> None:
 
 
 def test_role_with_no_web_need_gets_nothing() -> None:
-    assert derive_capabilities(
-        role="ceo", title="CEO", mandate="Owns the north star and ships the title."
-    ) == []
-    assert derive_capabilities(
-        role=None, title="Editor", mandate="Edit and polish drafts before publication."
-    ) == []
+    assert (
+        derive_capabilities(
+            role="ceo", title="CEO", mandate="Owns the north star and ships the title."
+        )
+        == []
+    )
+    assert (
+        derive_capabilities(
+            role=None, title="Editor", mandate="Edit and polish drafts before publication."
+        )
+        == []
+    )
 
 
 def test_derivation_is_word_boundaried_not_substring() -> None:
     # "resource"/"outsource" contain "source" but must NOT trip the web-fetch grant.
-    assert derive_capabilities(
-        role=None, title="Ops Lead", mandate="Allocate resources and outsource nothing."
-    ) == []
+    assert (
+        derive_capabilities(
+            role=None, title="Ops Lead", mandate="Allocate resources and outsource nothing."
+        )
+        == []
+    )
 
 
 # --- attach + model validation -----------------------------------------------

--- a/tests/test_run_policy.py
+++ b/tests/test_run_policy.py
@@ -1,0 +1,92 @@
+"""Bundle-configurable run-policy caps (ADR-027).
+
+Covers the deterministic role reasoning (CEO/root → tighter concurrency; a bounded poller →
+low turns; otherwise deployer-matching defaults), and the `.paperclip.yaml` `runPolicy`
+carrier, per-agent, wired through the full pipeline.
+"""
+
+from __future__ import annotations
+
+from ruamel.yaml import YAML
+
+from paperclip_blueprints.generators.client import LLMClient
+from paperclip_blueprints.models.agent import AgentDefinition
+from paperclip_blueprints.renderers.bundle import generate_bundle_full
+from paperclip_blueprints.renderers.render import render_files
+from paperclip_blueprints.renderers.run_policy import (
+    CEO_MAX_CONCURRENT_RUNS,
+    DEFAULT_MAX_CONCURRENT_RUNS,
+    DEFAULT_MAX_TURNS_PER_RUN,
+    POLLER_MAX_TURNS_PER_RUN,
+    assign_run_policies,
+    derive_run_policy,
+)
+from test_cli import _dispatch_full
+from test_models import _agent_kwargs
+from test_orchestration import _brief
+
+# --- pure reasoning ----------------------------------------------------------
+
+
+def test_defaults_match_the_deployer_defaults() -> None:
+    # A plain non-root worker with no poller signal keeps the current deployer behavior.
+    p = derive_run_policy(is_root=False, title="Writer", mandate="Draft and polish copy.")
+    assert p.max_turns_per_run == DEFAULT_MAX_TURNS_PER_RUN == 30
+    assert p.max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS == 2
+
+
+def test_ceo_gets_tighter_concurrency() -> None:
+    p = derive_run_policy(is_root=True, title="CEO", mandate="Owns the north star.")
+    assert p.max_concurrent_runs == CEO_MAX_CONCURRENT_RUNS == 1
+    assert p.max_turns_per_run == DEFAULT_MAX_TURNS_PER_RUN  # not a poller
+
+
+def test_bounded_poller_gets_low_turns() -> None:
+    p = derive_run_policy(
+        is_root=False, title="Signal Monitor", mandate="Monitor the queue and sweep for stalls."
+    )
+    assert p.max_turns_per_run == POLLER_MAX_TURNS_PER_RUN == 10
+    assert p.max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS
+
+
+def test_poller_signal_is_word_boundaried() -> None:
+    # "watchdog"/"sweepstakes" contain poller substrings but must NOT trip the low-turn cap.
+    p = derive_run_policy(
+        is_root=False, title="Ops", mandate="Run the watchdog demo and sweepstakes launch."
+    )
+    assert p.max_turns_per_run == DEFAULT_MAX_TURNS_PER_RUN
+
+
+def test_assign_run_policies_keys_by_slug() -> None:
+    ceo = AgentDefinition(**_agent_kwargs(slug="ceo", title="CEO", reports_to=None))
+    poller = AgentDefinition(
+        **_agent_kwargs(
+            slug="poller",
+            title="Poller",
+            reports_to="ceo",
+            mandate="Poll external feeds each hour.",
+        )
+    )
+    policies = assign_run_policies([ceo, poller])
+    assert policies["ceo"].max_concurrent_runs == 1
+    assert policies["poller"].max_turns_per_run == POLLER_MAX_TURNS_PER_RUN
+
+
+# --- .paperclip.yaml carrier -------------------------------------------------
+
+
+def test_paperclip_yaml_carries_per_agent_run_policy() -> None:
+    from test_templates import _config
+
+    out = render_files(_config())[".paperclip.yaml"]
+    ceo = YAML(typ="safe").load(out)["agents"]["ceo"]["runPolicy"]
+    assert ceo == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 1}
+
+
+def test_full_pipeline_emits_run_policy_for_each_role() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    out = render_files(config)[".paperclip.yaml"]
+    agents = YAML(typ="safe").load(out)["agents"]
+    # CEO (root) → tight concurrency; engineer (non-root worker) → default concurrency.
+    assert agents["ceo"]["runPolicy"] == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 1}
+    assert agents["engineer"]["runPolicy"] == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 2}


### PR DESCRIPTION
## What

The deployer set run-policy caps as hard-coded defaults (`adapterConfig.maxTurnsPerRun = 30`; `runtimeConfig.heartbeat.maxConcurrentRuns` = 1 for the CEO / 2 for others), so a company couldn't tune them per role. This makes them **bundle-driven**: generation reasons a `RunPolicy` per agent from role and emits it in `.paperclip.yaml`.

**Emit side only** — the deployer consumer (reading `runPolicy` instead of hard-coding) lives elsewhere. Additive and behavior-preserving: the defaults match the deployer's, so nothing changes until a bundle differs.

## Reasoning (deterministic, no LLM)

- **`maxConcurrentRuns`** — CEO/org-root → `1` (tighter concurrency for the decision-maker); every other agent → `2`.
- **`maxTurnsPerRun`** — a bounded poller (title/mandate signals `poll`/`monitor`/`watch`/`sweep`, word-boundaried so `watchdog`/`sweepstakes` don't trip) → `10`; otherwise → `30`.

Defaults (`30`; CEO `1` / others `2`) match the deployer's current hard-coded defaults, so behavior is unchanged for any role the reasoning doesn't tighten.

## Carrier

Per-agent `runPolicy` block in `.paperclip.yaml`, alongside `adapter`/`budgetMonthlyCents`:

```yaml
agents:
  ceo:
    runPolicy:
      maxTurnsPerRun: 30
      maxConcurrentRuns: 1
```

The deployer maps `runPolicy.maxTurnsPerRun → adapterConfig.maxTurnsPerRun` and `runPolicy.maxConcurrentRuns → runtimeConfig.heartbeat.maxConcurrentRuns`. Carrier decision + rejected alternatives (mirror the deployer's split nesting; LLM reasoning; brief-level caps) in ADR-027.

## Tests (+7)

defaults-match-deployer; CEO tighter concurrency; poller low turns; word-boundary (watchdog/sweepstakes → default); `assign_run_policies` keying; `.paperclip.yaml` carrier round-trip; full-pipeline per-role.

## Note on the second commit

`daf2a4c` reformats `tests/test_capabilities.py` (an already-merged file) — a **pre-existing ruff 0.15.15 drift** unrelated to this feature (an earlier ruff considered it clean, so it passed its own gate). It's the only non-F5 file affected; folded here as a separate labeled commit so the repo passes `ruff format --check`. A follow-up PR pins ruff so this can't recur.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest 357 passed, 2 skipped (+7 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)