### PR TITLE
chore: pin ruff to avoid format drift

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,9 @@
 repos:
   # Python linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.0
+    # Pinned exactly to match the `ruff==` pin in pyproject.toml — the formatter is not
+    # stable across versions, so a bump can reformat already-merged files. Bump both together.
+    rev: v0.15.15
     hooks:
       - id: ruff
         args: [--fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ blueprints = "paperclip_blueprints.cli:app"
 [dependency-groups]
 dev = [
     "pytest>=8.0",
-    "ruff>=0.6",
+    # ruff is pinned exactly: the formatter is not stable across versions, so a bump can
+    # reformat already-merged files mid-session. Keep in sync with .pre-commit-config.yaml.
+    "ruff==0.15.15",
     "pyright>=1.1.380",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,10 @@ build-backend = "hatchling.build"
 packages = ["src/paperclip_blueprints"]
 
 [tool.ruff]
+# Pinned exactly (matches the `ruff==` dev-dep and the pre-commit rev): ruff refuses to run
+# under a different version, so a bump can't silently reformat already-merged files. Bump all
+# three together.
+required-version = "==0.15.15"
 target-version = "py311"
 line-length = 100
 src = ["src", "tests"]

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -42,19 +42,28 @@ def test_research_role_gets_web_fetch() -> None:
 
 
 def test_role_with_no_web_need_gets_nothing() -> None:
-    assert derive_capabilities(
-        role="ceo", title="CEO", mandate="Owns the north star and ships the title."
-    ) == []
-    assert derive_capabilities(
-        role=None, title="Editor", mandate="Edit and polish drafts before publication."
-    ) == []
+    assert (
+        derive_capabilities(
+            role="ceo", title="CEO", mandate="Owns the north star and ships the title."
+        )
+        == []
+    )
+    assert (
+        derive_capabilities(
+            role=None, title="Editor", mandate="Edit and polish drafts before publication."
+        )
+        == []
+    )
 
 
 def test_derivation_is_word_boundaried_not_substring() -> None:
     # "resource"/"outsource" contain "source" but must NOT trip the web-fetch grant.
-    assert derive_capabilities(
-        role=None, title="Ops Lead", mandate="Allocate resources and outsource nothing."
-    ) == []
+    assert (
+        derive_capabilities(
+            role=None, title="Ops Lead", mandate="Allocate resources and outsource nothing."
+        )
+        == []
+    )
 
 
 # --- attach + model validation -----------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ requires-dist = [
 dev = [
     { name = "pyright", specifier = ">=1.1.380" },
     { name = "pytest", specifier = ">=8.0" },
-    { name = "ruff", specifier = ">=0.6" },
+    { name = "ruff", specifier = "==0.15.15" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The ruff **formatter is not stable across versions**, so a mid-session ruff bump can reformat already-merged files. This session, ruff 0.15.15 rewrapped an `assert f(...) == []` pattern in an F3 test that an earlier ruff considered clean — surfacing only when an unrelated PR ran `ruff format`.

Pin ruff **exactly** so formatting is reproducible:
- `pyproject.toml` dev group: `ruff>=0.6` → `ruff==0.15.15`
- `.pre-commit-config.yaml`: `rev: v0.6.0` → `rev: v0.15.15`
- `uv.lock` updated to the pin.

Comments in both files note they must be bumped together.

## Also

Reformats `tests/test_capabilities.py` to 0.15.15 so the repo is clean under the pin. This is the **same one-file change as F5's `daf2a4c`** (byte-identical), so it resolves cleanly whichever of the two PRs merges first — no conflict either way.

## Gates

ruff check clean · `ruff format --check` clean · pyright 0/0/0 · pytest 350 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)