### PR TITLE
feat(014): per-agent run-policy overrides from the brief

### DIFF
--- a/docs/adr/034-brief-run-policy-override.md
+++ b/docs/adr/034-brief-run-policy-override.md
@@ -87,6 +87,21 @@ Scope is the emit/carrier side only. The deployer that consumes `runPolicy` (inc
   because the field defaults to `None` and renders nothing.
 - The role rule (ADR-027) is untouched — this ADR extends it, it does not supersede it.
 
+### Deviation from the draft contract — cross-reference collision resolves silently
+
+The `contracts/run-policy-override.md` §5 draft specified that when two **distinct** brief lines
+overlap on one agent+field, generation emits an advisory collision warning. The implementation
+**deliberately does not**: a collision resolves deterministically last-in-line-order with **no
+warning**, and the contract §5 has been updated to match.
+
+Rationale: broad-then-specific overlap is a **supported, intentional pattern** — an operator can
+write a broad default (`All watchers: max turns 5`) and then a specific exception
+(`lead-watcher: max turns 12`) for the same agent. A collision warning would therefore fire on
+*correct* usage, training operators to ignore it. The determinism guarantee (FR-008) is unaffected:
+the later line wins per field, in stable brief-line order. Recorded here as a decision, not a silent
+omission — the unmatched-reference warning (FR-009) is retained because a reference that matches
+*no* agent is a likely typo, whereas an overlap on a real agent is not.
+
 ## Alternatives considered
 
 - **Supersede ADR-027 — remove the role heuristics, emit only brief-stated values.** Rejected: the

--- a/docs/adr/034-brief-run-policy-override.md
+++ b/docs/adr/034-brief-run-policy-override.md
@@ -1,0 +1,113 @@
+# ADR-034: Layer a brief-driven per-agent run-policy override over the role-derived base
+
+## Status
+
+Accepted
+
+## Date
+
+2026-07-20
+
+## Context
+
+The generator emits a per-agent `runPolicy` block in `.paperclip.yaml` (ADR-027): a role rule
+derives `maxTurnsPerRun` and `maxConcurrentRuns` for every agent. The operator has no way to state
+run-policy values for a specific agent from the brief — the values are chosen entirely by the role
+rule. An agent wake with no bound on turns or concurrency can loop and burn budget before anything
+stops it, and an operator who knows a given agent should be tightly bounded (or should never run on
+a heartbeat) cannot express that in the brief.
+
+Two established derivations already show how a brief drives a per-agent `.paperclip.yaml` value with
+a pure, deterministic renderer: per-agent budgets (ADR-012, `renderers/budget.py`, keyed off
+`capital_monthly_eur`) and per-agent model preferences (ADR-017, `renderers/adapter.py`,
+`parse_model_preferences` overlaying the brief's stated model onto a role default). ADR-027 itself
+anticipated this exact extension: "Add per-company/per-role caps to the operator brief. Deferred …
+a brief knob can layer on top later (as ADR-017 layered explicit model preferences over role
+defaults)."
+
+Choosing *what values are appropriate* for a role — the enforcement reasoning — is out of scope for
+this repository. This feature is a carrier: it transports operator-stated values and infers nothing.
+
+## Decision
+
+Add a brief-driven override that **layers on top of** the ADR-027 role-derived base. ADR-027's role
+rule remains the base and is emitted for every agent unchanged; a brief-stated value substitutes for
+the role-derived value **per agent and per field**.
+
+1. **New brief channel.** `CompanyBrief.run_policy_preferences: list[str] | None`
+   (`models/input.py`), parsed from a new optional input-template section (FR-013), shaped like the
+   existing `adapter_preferences` free-text override lines. Each line:
+   `<agent reference>: <clause>[, <clause>]...`, where a clause sets `max turns <N>`,
+   `max concurrent <N>`, or `heartbeat <on|off>`.
+
+2. **Pure renderer.** `parse_run_policy_preferences(lines, agents)` in `renderers/run_policy.py`
+   resolves lines to per-slug `RunPolicyOverride`s using the same boundary-safe reference matcher as
+   `parse_model_preferences`. `assign_run_policies(agents, overrides)` overlays each stated field
+   onto the role-derived `RunPolicy`; unset fields keep the base. Deterministic, no LLM, no I/O.
+
+3. **Heartbeat is brief-only.** `RunPolicy` gains `heartbeat_enabled: bool | None = None`. There is
+   no role heuristic behind it; it is emitted (`runPolicy.heartbeatEnabled`) only when the brief
+   states it and is absent otherwise.
+
+4. **No new value-choosing.** This feature adds no default, heuristic, or inference — it emits only
+   values the operator stated. Choosing appropriate run-policy values by role/risk/company shape
+   stays out of this repository.
+
+5. **Validation split.** Malformed *values* (non-positive/non-integer turns or concurrency,
+   unrecognized clause or heartbeat token, a reference given conflicting values for one field) are
+   rejected at brief-validation time. A reference matching *no* generated agent is a non-blocking
+   render-time warning (the org isn't known at brief-parse time), mirroring the adapter
+   unmatched-preference warning.
+
+Scope is the emit/carrier side only. The deployer that consumes `runPolicy` (including mapping
+`heartbeatEnabled` to a runtime heartbeat setting) lives in the private repo and is unchanged here.
+
+## Consequences
+
+### Positive consequences
+
+- An operator can bound a specific agent's turns and concurrency, and disable its heartbeat, from
+  the brief — directly addressing unbounded wakes that loop and burn budget.
+- Backward compatible: a brief with no run-policy values yields byte-identical output to today's
+  (`assign_run_policies(agents)` with no overrides equals the current result).
+- Consistent with the two existing per-agent brief-driven derivations (budget, model preference):
+  same seam, same matcher, same pure-renderer shape — low conceptual surface.
+- Value-choosing stays out of the public repo; the carrier only transports what the operator wrote.
+
+### Negative consequences
+
+- Adds a brief channel and grammar (input-template section + parser + validation) that ADR-027 had
+  deferred — more input-parsing surface to maintain.
+- Two override lines with distinct references can collide onto one agent; resolved by a
+  deterministic last-in-order rule plus a warning, which an operator could find surprising.
+
+### Neutral consequences
+
+- `RunPolicy` gains an optional third field; all existing call sites keep the two-key emission
+  because the field defaults to `None` and renders nothing.
+- The role rule (ADR-027) is untouched — this ADR extends it, it does not supersede it.
+
+## Alternatives considered
+
+- **Supersede ADR-027 — remove the role heuristics, emit only brief-stated values.** Rejected: the
+  operator chose to keep the role rule as the base and layer the brief override on top; a
+  silent-when-unstated pure carrier would also change today's output (pollers lose their tightened
+  turns).
+- **Default the heartbeat toggle to enabled and always emit it.** Rejected: that is an inferred
+  value the operator did not state (violates the no-inference rule) and would change today's output.
+- **Whole-object replacement when any field is stated.** Rejected: breaks field independence —
+  stating turns would wipe the role-derived concurrency.
+- **A structured YAML block in the brief instead of free-text lines.** Rejected: the brief is
+  prose-shaped Markdown (ADR-003); free-text override lines match the established input idiom and
+  reuse the adapter reference matcher verbatim.
+
+## References
+
+- `specs/014-run-policy-override/` — spec, plan, research, data-model, contracts, quickstart
+- `src/paperclip_blueprints/renderers/run_policy.py` — role base (ADR-027) + this override layer
+- `src/paperclip_blueprints/renderers/adapter.py` — `parse_model_preferences`, the boundary-safe
+  reference matcher reused here
+- `src/paperclip_blueprints/renderers/budget.py` — the per-agent brief-driven derivation precedent
+- ADR-027 (role-derived run-policy caps; the base this layers over), ADR-017 (per-agent model
+  preference over role default; the layering pattern), ADR-012 (per-agent budget), ADR-003 (brief
+  input format)

--- a/examples/input-template.md
+++ b/examples/input-template.md
@@ -243,6 +243,25 @@ Free text for anything important that doesn't fit above. The tool incorporates t
 
 ---
 
+## 12. Run-policy overrides (optional)
+
+By default the tool sets each agent's per-run turn cap and concurrent-run limit by role. If you want a specific agent bounded differently — or run only on demand, never on a heartbeat — state it here. An agent wake with no bound on turns or concurrency can loop and burn budget before anything stops it; these overrides let you cap that. **Leave this blank to keep the defaults — an empty section changes nothing.**
+
+One override per line, naming the agent and any of the three values (combine on one line, comma-separated):
+
+- `<agent>: max turns <N>` — cap turns per wake (guards against a run that loops)
+- `<agent>: max concurrent <N>` — cap simultaneous runs of that agent
+- `<agent>: heartbeat off` — do not wake this agent on a heartbeat (`on`/`off`)
+
+Name the agent by role, title, or slug — the same way as adapter preferences. A name that matches no agent is skipped with a warning; a bad value (e.g. `max turns 0`) is rejected before generation.
+
+**Your overrides:**
+
+- [e.g., "research-analyst: max turns 8, heartbeat off"]
+- [e.g., "CEO: max concurrent 1"]
+
+---
+
 ## Validation checklist
 
 Before passing this to the tool, verify:

--- a/specs/014-run-policy-override/checklists/requirements.md
+++ b/specs/014-run-policy-override/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: Per-agent run-policy override from the brief
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-20
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- The one deliberate near-implementation reference is "the same boundary-safe reference matching
+  already used for per-role brief overrides" (FR-002). This is retained on purpose: it fixes an
+  operator-visible behavior (operators name agents the same way they already do for adapter
+  preferences) and reuses an established, documented convention rather than inventing a new one. It
+  names no language, framework, or API.
+- The bundle-carrier and role-derived base are described as existing behavior the feature layers
+  onto, not as new implementation choices.
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`. None
+  are incomplete.

--- a/specs/014-run-policy-override/contracts/run-policy-override.md
+++ b/specs/014-run-policy-override/contracts/run-policy-override.md
@@ -117,8 +117,13 @@ rendered block is byte-identical to today's. (SC-002)
 
 - Unmatched reference: `run-policy override <line> names no agent — no run policy is set for it`
   (advisory; generation proceeds). Mirrors the adapter unmatched-preference warning. (FR-009)
-- Cross-reference collision on one agent+field: `run-policy overrides conflict for agent <slug> on
-  <field>; taking the last (<value>)` (advisory; deterministic last-wins). (D4)
+- Cross-reference collision on one agent+field: resolved **deterministically last-in-line-order
+  with no warning**. Two distinct references legitimately overlapping on one agent — a broad
+  default plus a specific exception (e.g. `All watchers: max turns 5` then
+  `lead-watcher: max turns 12`) — is a **supported, intentional pattern**, so a collision warning
+  would fire on correct usage. The later line wins per field; determinism holds (FR-008). See
+  ADR-034 (recorded as a deliberate deviation from this contract's original draft, which specified
+  an advisory warning here). (D4)
 
 ## 6. Input-template section text (added to `examples/input-template.md`, FR-013)
 

--- a/specs/014-run-policy-override/contracts/run-policy-override.md
+++ b/specs/014-run-policy-override/contracts/run-policy-override.md
@@ -1,0 +1,141 @@
+# Contract: Per-agent run-policy override from the brief
+
+This is a library + CLI tool; the "interfaces" are the module function signatures, the brief input
+grammar, the emitted `.paperclip.yaml` fragment, and the input-template section.
+
+## 1. Module interface — `renderers/run_policy.py`
+
+```python
+@dataclass(frozen=True)
+class RunPolicy:
+    max_turns_per_run: int
+    max_concurrent_runs: int
+    heartbeat_enabled: bool | None = None      # NEW: None => not stated => not emitted
+
+
+@dataclass(frozen=True)
+class RunPolicyOverride:
+    max_turns_per_run: int | None = None
+    max_concurrent_runs: int | None = None
+    heartbeat_enabled: bool | None = None
+
+
+def parse_run_policy_preferences(
+    preferences: Sequence[str] | None,
+    agents: Sequence[_AgentRef],
+) -> tuple[dict[str, RunPolicyOverride], list[str]]:
+    """Resolve brief run-policy override lines to per-slug overrides.
+
+    Returns (overrides, unmatched):
+      - overrides: agent slug -> RunPolicyOverride (only agents an override matched)
+      - unmatched: override lines whose reference matched no agent (caller warns)
+    Boundary-safe reference matching reuses adapter._matched_ref / _boundary_contains.
+    Assumes lines are already syntactically valid (validated at brief-parse time).
+    """
+
+
+def assign_run_policies(
+    agents: list[AgentDefinition],
+    overrides: dict[str, RunPolicyOverride] | None = None,   # NEW optional param
+) -> dict[str, RunPolicy]:
+    """Role-derived base (ADR-027) with per-agent, per-field brief overrides applied.
+
+    overrides is None/empty => identical to today's output (backward compat).
+    Field overlay: a set override field replaces the base; unset fields keep the base.
+    heartbeat_enabled has no base — it is None unless an override sets it.
+    """
+```
+
+**Contract guarantees**
+- `assign_run_policies(agents)` (no `overrides`) returns exactly today's result — same call sites,
+  same values. (SC-002 / FR-006)
+- `parse_run_policy_preferences(None, agents) == ({}, [])`.
+- Pure/deterministic: no I/O, no model call; output depends only on inputs. (FR-008)
+- No field is ever populated from role/risk/shape — only from a stated override. (FR-007)
+
+## 2. Brief input grammar (new input-template section)
+
+One override per line:
+
+```
+<agent reference>: <clause>[, <clause>]...
+```
+
+Clauses (case-insensitive; hyphen or space tolerated):
+
+| Concern | Keyword (aliases) | Value |
+|---|---|---|
+| Turns cap | `max turns` (`turns`, `max-turns`) | positive integer |
+| Concurrency limit | `max concurrent` (`concurrent`, `max-concurrent`, `concurrency`) | positive integer |
+| Heartbeat | `heartbeat` | `on`/`enabled`/`true` or `off`/`disabled`/`false` |
+
+Examples:
+
+```
+research-analyst: max turns 8, heartbeat off
+CEO: max concurrent 1
+All watchers: max turns 5
+```
+
+- Reference = text left of the first `:`; matched boundary-safe to slug / title / name.
+- A line must contain ≥1 clause.
+- Rejected at brief-validation time: non-positive/non-integer value, unknown clause keyword,
+  unknown heartbeat state, same reference with conflicting values for one field. (FR-010)
+
+## 3. Emitted `.paperclip.yaml` fragment (`templates/paperclip_yaml.j2`)
+
+```yaml
+agents:
+  research-analyst:
+    runPolicy:
+      maxTurnsPerRun: 8          # brief override (base would be role-derived)
+      maxConcurrentRuns: 2       # role-derived base (unstated by brief)
+      heartbeatEnabled: false    # brief-stated only; omitted when unstated
+```
+
+Template change (additive, inside the existing `runPolicy` block):
+
+```jinja
+    runPolicy:
+      maxTurnsPerRun: {{ run_policies[a.slug].max_turns_per_run }}
+      maxConcurrentRuns: {{ run_policies[a.slug].max_concurrent_runs }}
+{% if run_policies[a.slug].heartbeat_enabled is not none %}
+      heartbeatEnabled: {{ run_policies[a.slug].heartbeat_enabled | lower }}
+{% endif %}
+```
+
+**Guarantee**: when no agent has a stated heartbeat and no override changes turns/concurrency, the
+rendered block is byte-identical to today's. (SC-002)
+
+## 4. Validator contract (`validators/schema_shape.py`)
+
+- `runPolicy.heartbeatEnabled`, when present, MUST be a boolean; a non-boolean is a schema-shape
+  failure that blocks the write. (Constitution II)
+- No change to the existing `maxTurnsPerRun` / `maxConcurrentRuns` assertions.
+
+## 5. Warning contract (`renderers/render.py`, via `warn` sink)
+
+- Unmatched reference: `run-policy override <line> names no agent — no run policy is set for it`
+  (advisory; generation proceeds). Mirrors the adapter unmatched-preference warning. (FR-009)
+- Cross-reference collision on one agent+field: `run-policy overrides conflict for agent <slug> on
+  <field>; taking the last (<value>)` (advisory; deterministic last-wins). (D4)
+
+## 6. Input-template section text (added to `examples/input-template.md`, FR-013)
+
+> ## N. Run-policy overrides (optional)
+>
+> By default the tool sets each agent's per-run turn cap and concurrent-run limit by role. If you
+> want a specific agent bounded differently — or run only on demand, never on a heartbeat — state it
+> here. Leave this blank to keep the defaults; an empty section changes nothing.
+>
+> One override per line, naming the agent and the values:
+>
+> - `<agent>: max turns <N>` — cap turns per wake (guards against a run that loops and burns budget)
+> - `<agent>: max concurrent <N>` — cap simultaneous runs of that agent
+> - `<agent>: heartbeat off` — do not wake this agent on a heartbeat (on/off)
+>
+> Combine on one line: `research-analyst: max turns 8, heartbeat off`
+>
+> **Your overrides:**
+>
+> - [e.g., "CEO: max concurrent 1"]

--- a/specs/014-run-policy-override/data-model.md
+++ b/specs/014-run-policy-override/data-model.md
@@ -1,0 +1,84 @@
+# Phase 1 Data Model: Per-agent run-policy override from the brief
+
+## Entities
+
+### RunPolicyOverride (new)
+
+An operator-stated, per-agent set of optional run-policy values, parsed from one brief line. All
+fields optional; at least one is set (a line with no clause is a syntactic error).
+
+| Field | Type | Notes |
+|---|---|---|
+| `max_turns_per_run` | `int \| None` | Positive integer when set; `None` = not stated. |
+| `max_concurrent_runs` | `int \| None` | Positive integer when set; `None` = not stated. |
+| `heartbeat_enabled` | `bool \| None` | `None` = not stated (nothing emitted); `True`/`False` = explicit toggle. |
+
+Represented as a frozen dataclass in `renderers/run_policy.py` (a transport value, not a persisted
+model — mirrors `AdapterChoice`). It is keyed by resolved agent slug in the override map.
+
+### RunPolicy (extended)
+
+The existing ADR-027 result, plus one new field.
+
+| Field | Type | Source |
+|---|---|---|
+| `max_turns_per_run` | `int` | Role-derived base (ADR-027), or brief override. Always present. |
+| `max_concurrent_runs` | `int` | Role-derived base (ADR-027), or brief override. Always present. |
+| `heartbeat_enabled` | `bool \| None` (**new**, default `None`) | Brief-only. `None` renders nothing. |
+
+Backward-compat: the new field defaults to `None`, so a `RunPolicy` built without it (all existing
+call sites and tests) is unchanged and renders exactly today's two-key block.
+
+### CompanyBrief (extended)
+
+One new optional field on the existing Pydantic model in `models/input.py`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `run_policy_preferences` | `list[str] \| None = None` | Raw override lines from the new input-template section. `None`/empty ⇒ feature dormant. Mirrors `adapter_preferences`. |
+
+## Derivation flow
+
+```
+brief.run_policy_preferences (raw lines)
+        │  parse_run_policy_preferences(lines, agents)      [renderers/run_policy.py]
+        ▼
+(overrides: dict[slug -> RunPolicyOverride], unmatched: list[str])
+        │  merge over assign_run_policies(agents)  (role-derived base, ADR-027)
+        ▼
+run_policies: dict[slug -> RunPolicy]   → template context "run_policies" (render.py)
+        │  paperclip_yaml.j2 runPolicy block
+        ▼
+.paperclip.yaml  (maxTurnsPerRun, maxConcurrentRuns, [heartbeatEnabled])
+```
+
+`unmatched` → `warn(...)` in `render.py` (advisory, non-blocking).
+
+## Validation rules (mapped to FRs)
+
+Syntactic (at `parse_brief` / `CompanyBrief` validation → `BriefValidationError`, no agents needed):
+
+| Rule | FR | Message intent |
+|---|---|---|
+| A turns / concurrency value is a positive integer | FR-010 | name the line + the offending value |
+| Clause keyword is recognized (turns / concurrent / heartbeat + aliases) | FR-010 | name the unrecognized token |
+| Heartbeat state is a recognized on/off token | FR-010 | name the unrecognized state |
+| A line has at least one clause | FR-010 | "run-policy override states no value" |
+| The **same reference** is not given conflicting values for one field | FR-010 | name the reference + field |
+
+Semantic (at render time → `warn`, non-blocking):
+
+| Rule | FR | Behavior |
+|---|---|---|
+| Reference matches ≥1 generated agent | FR-009 | no match ⇒ warn, emit nothing for it |
+| Two distinct references collide on one agent+field with conflicting values | edge (D4) | warn, last-in-line-order wins (deterministic) |
+
+Invariants:
+
+- **No-op identity** (FR-006, SC-002): `run_policy_preferences` empty/`None` ⇒ `overrides` empty ⇒
+  `run_policies` equals `assign_run_policies(agents)` exactly ⇒ byte-identical `.paperclip.yaml`.
+- **Field independence** (FR-004): overriding one field never mutates another.
+- **Heartbeat-only-when-stated** (FR-005, SC-004): `heartbeat_enabled is None` ⇒ key absent.
+- **No inference** (FR-007): the parser reads only stated tokens; it never fills a value from role,
+  risk, or company shape.
+- **Determinism** (FR-008): pure function of `(lines, agents)`; brief-line order is the only tie-break.

--- a/specs/014-run-policy-override/plan.md
+++ b/specs/014-run-policy-override/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Per-agent run-policy override from the brief
+
+**Branch**: `014-run-policy-override` | **Date**: 2026-07-20 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/014-run-policy-override/spec.md`
+
+## Summary
+
+Let the operator's brief state per-agent run-policy values — a maximum-turns-per-run cap, a
+maximum-concurrent-runs limit, and a heartbeat on/off toggle — and carry those exact values into
+the bundle's `.paperclip.yaml` `runPolicy` block so the deployer applies them. The feature layers
+a **pure, deterministic override** on top of the existing role-derived run policy (ADR-027): a
+brief-stated value substitutes for the role-derived value for that agent and field; the role rule
+is the untouched base. The heartbeat toggle is a new, brief-only field emitted only when stated.
+No new defaults, heuristics, or inference — the module transports operator-stated values and
+nothing else. Structure mirrors the two established per-agent brief-driven derivations: budget
+(ADR-012, `renderers/budget.py`) and model preferences (ADR-017, `renderers/adapter.py`,
+`parse_model_preferences`). Emit/carrier side only; the deployer consumer lives in the private
+repo and is out of scope.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+
+
+**Primary Dependencies**: Pydantic v2 (brief model + validation), Jinja2 (`paperclip_yaml.j2`
+carrier), ruamel.yaml (round-trip). No new dependency — the feature is pure Python over existing
+libraries.
+
+**Storage**: N/A (in-memory generation → files on disk).
+
+**Testing**: pytest, test-first per Constitution III. New `tests/test_run_policy.py` cases (the
+file exists) plus brief-parsing cases in `tests/test_models.py` and a render-path assertion.
+
+**Target Platform**: CLI tool (local generation).
+
+**Project Type**: Single project (library + Typer CLI).
+
+**Performance Goals**: N/A — deterministic, no I/O, no model call; negligible cost.
+
+**Constraints**: Pure and deterministic (no LLM, no I/O); byte-identical output when the brief
+states nothing (backward-compat gate); generated `.paperclip.yaml` stays schema-valid
+(Constitution II).
+
+**Scale/Scope**: A single company bundle (typically 8–16 agents). One new brief field, one new
+input-template section, additions to one renderer module, one template block, and validation.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Spec-Driven Development First** — PASS. `/speckit.specify` → this plan → `/speckit.tasks` →
+  `/speckit.implement`, in order. Spec is settled and validated.
+- **II. Schema-Valid Bundles (NON-NEGOTIABLE)** — PASS with a named check. The new
+  `runPolicy.heartbeatEnabled` key is additive under a block the validators already tolerate
+  (ADR-027 renders `runPolicy` today; `test_run_policy.py` and the schema-shape/integrity
+  validators are green). The plan requires the bundle validators to stay green with the new key,
+  and adds a validator assertion so a malformed emission cannot reach disk.
+- **III. Test-First for Non-Trivial Logic** — PASS. The line parser, the override merge, and the
+  brief-field validation are non-trivial and MUST be built red-green-refactor. Pure-templating glue
+  (the one `{% if %}` in the Jinja block) is exempt.
+- **IV. Brief-Faithful Generation Over Recycled Shape** — PASS, and strongly reinforced. The
+  feature is pure passthrough of operator-stated values with an explicit no-inference rule
+  (FR-007); no model creativity is involved. This is the "structural rule the tool enforces, not a
+  model preference" principle applied to run-policy values.
+- **V. Phased Scope & YAGNI** — PASS. This is v0.1b carrier work (the bundle the operator imports).
+  The deployer that consumes `runPolicy` is v0.2 / private-repo scope and is explicitly excluded
+  (FR-012). No deployment automation is added here.
+
+No violations → Complexity Tracking table omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-run-policy-override/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — grammar & layering decisions
+├── data-model.md        # Phase 1 output — entities & validation rules
+├── quickstart.md        # Phase 1 output — operator + developer walkthrough
+├── contracts/
+│   └── run-policy-override.md   # Module interface, brief field, YAML carrier, template section
+├── checklists/
+│   └── requirements.md  # From /speckit.specify
+└── tasks.md             # /speckit.tasks output (NOT created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/paperclip_blueprints/
+├── models/
+│   └── input.py                 # CHANGE: add `run_policy_preferences: list[str] | None`;
+│                                #         parse a new input-template section; syntactic
+│                                #         validation of stated values (FR-010)
+├── renderers/
+│   ├── run_policy.py            # CHANGE: add `heartbeat_enabled` to RunPolicy; add
+│   │                            #         `parse_run_policy_preferences(...)`; add an
+│   │                            #         override-merge over the role-derived base
+│   ├── adapter.py               # REUSE (import only): boundary-safe matching helpers
+│   │                            #         (`_matched_ref`, `_boundary_contains`)
+│   └── render.py                # CHANGE: parse brief overrides, merge onto role base,
+│                                #         surface unmatched-reference warnings via `warn`
+├── templates/
+│   └── paperclip_yaml.j2        # CHANGE: emit `heartbeatEnabled` under runPolicy when present
+└── validators/
+    └── schema_shape.py          # VERIFY/EXTEND: runPolicy block (incl. heartbeatEnabled) shape
+
+examples/
+└── input-template.md            # CHANGE: new "Run-policy overrides (optional)" section (FR-013)
+
+tests/
+├── test_run_policy.py           # EXTEND: parser, merge, heartbeat-only-when-stated, no-op
+├── test_models.py               # EXTEND: brief field parsing + malformed-value rejection
+└── test_render.py / test_bundle.py  # EXTEND: byte-identical no-op; emitted values; warnings
+
+docs/adr/
+└── 034-brief-run-policy-override.md   # NEW ADR (number 034 per operator instruction)
+```
+
+**Structure Decision**: Single-project layout, extending the existing per-agent-derivation seam.
+The feature slots into the exact three places budget and adapter preferences already occupy: a
+brief field + parser (`models/input.py`), a pure renderer (`renderers/run_policy.py`), and the
+`.paperclip.yaml` carrier (`render.py` context + `paperclip_yaml.j2`). No new module directory, no
+new dependency, no new top-level structure.
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Resolves: the brief line grammar (colon-delimited
+reference + typed clauses), where malformed-value validation lives (syntactic → brief validation;
+semantic match → render-time warning), the heartbeat carrier key (`runPolicy.heartbeatEnabled`),
+and the layering mechanics over ADR-027 (field-level override, base untouched).
+
+## Phase 1 — Design & Contracts
+
+- [data-model.md](./data-model.md) — the `RunPolicyOverride` entity, the extended `RunPolicy`, the
+  new brief field, and all validation rules mapped to FRs.
+- [contracts/run-policy-override.md](./contracts/run-policy-override.md) — the module function
+  signatures, the brief-section grammar, the `.paperclip.yaml` `runPolicy` fragment, and the
+  input-template section text.
+- [quickstart.md](./quickstart.md) — an operator walkthrough (write an override, see it in the
+  bundle) and a developer walkthrough (run the tests).
+
+**Agent context update**: SKIPPED. CLAUDE.md contains no `<!-- SPECKIT START/END -->` markers, and
+the operator rule forbids modifying CLAUDE.md without an ADR. The "Active feature plan" pointer is
+left as the operator's to move.
+
+**Decision record**: `docs/adr/034-brief-run-policy-override.md` is authored in this phase (the
+layering-over-ADR-027 decision + the new brief channel). Numbered 034 per operator instruction (028
+is skipped here).

--- a/specs/014-run-policy-override/quickstart.md
+++ b/specs/014-run-policy-override/quickstart.md
@@ -1,0 +1,60 @@
+# Quickstart: Per-agent run-policy override from the brief
+
+## For the operator
+
+1. In your filled-in brief (from `examples/input-template.md`), find the optional **Run-policy
+   overrides** section.
+2. Add one line per agent you want to bound. You can set any subset of three things:
+   - `max turns <N>` — a per-wake turn cap (stops an agent that loops)
+   - `max concurrent <N>` — a limit on simultaneous runs of that agent
+   - `heartbeat off` — never wake this agent on a heartbeat (it runs only when given work)
+
+   ```
+   research-analyst: max turns 8, heartbeat off
+   CEO: max concurrent 1
+   ```
+
+3. Generate the bundle as usual. In `.paperclip.yaml`, the named agents now carry your values under
+   `runPolicy`:
+
+   ```yaml
+   research-analyst:
+     runPolicy:
+       maxTurnsPerRun: 8
+       maxConcurrentRuns: 2       # unchanged role default (you didn't set it)
+       heartbeatEnabled: false
+   ```
+
+4. **Leave the section blank and nothing changes** — every agent keeps the values the tool sets by
+   role today. This feature only adds values you explicitly write.
+
+**Notes**
+- Name an agent the same way you name it in adapter preferences — by role, title, or slug; matching
+  is boundary-safe (`analyst` won't match `senior-analyst`).
+- A name that matches no agent produces a warning (not an error) and is skipped.
+- A bad value (e.g. `max turns 0`, or `heartbeat maybe`) is rejected up front with a clear message,
+  before any generation runs.
+
+## For the developer
+
+The feature follows the per-agent budget / model-preference precedent: a pure, deterministic
+renderer driven by the brief, no model call.
+
+- Brief field: `CompanyBrief.run_policy_preferences: list[str] | None` (`models/input.py`), parsed
+  from the new input-template section; malformed values rejected in brief validation.
+- Parse + match: `parse_run_policy_preferences(lines, agents)` (`renderers/run_policy.py`) reusing
+  `adapter.py`'s boundary-safe matcher.
+- Merge: `assign_run_policies(agents, overrides)` overlays stated fields onto the ADR-027 role base.
+- Carrier: `render.py` puts the merged map in the template context; `paperclip_yaml.j2` emits
+  `heartbeatEnabled` only when set.
+
+Run the checks:
+
+```bash
+uv run pytest tests/test_run_policy.py tests/test_models.py -q
+uv run pytest -q            # full suite — includes the byte-identical no-op assertion
+uv run ruff check . && uv run ruff format --check . && uv run pyright
+```
+
+Backward-compat gate: a brief with no `run_policy_preferences` must produce a `.paperclip.yaml`
+identical to current `main` for the same brief (the no-op test asserts this).

--- a/specs/014-run-policy-override/research.md
+++ b/specs/014-run-policy-override/research.md
@@ -1,0 +1,125 @@
+# Phase 0 Research: Per-agent run-policy override from the brief
+
+All decisions are deterministic-carrier decisions. None involve model behavior or value-choosing —
+the recurring constraint is that the feature transports what the operator wrote and invents nothing.
+
+## D1 — Layering mechanics over the role-derived base (ADR-027)
+
+**Decision**: The role rule (`derive_run_policy`) remains the base and is emitted for every agent
+exactly as today. A brief override substitutes values **per agent and per field**: if the brief
+states `maxTurnsPerRun` for an agent, only that agent's turns value changes; concurrency keeps its
+role-derived value unless the brief also states it. The merge is a field-level overlay, not a
+whole-object replacement.
+
+**Rationale**: Matches the spec's "override the role-derived value for that agent and field"
+(FR-003) and field independence (FR-004). Keeps backward-compat trivially true: with no overrides,
+the overlay is empty and output is byte-identical (FR-006, SC-002). Mirrors how
+`parse_model_preferences` overlays only the *model* onto the role-default `AdapterChoice`.
+
+**Alternatives considered**:
+- *Replace the whole role-derived `RunPolicy` when any field is stated.* Rejected: violates field
+  independence — stating turns would wipe the role-derived concurrency.
+- *Remove the role rule and emit only brief-stated values (supersede ADR-027).* Rejected: this was
+  the explicit fork decision — the operator chose "layer on top," keeping ADR-027 as the base.
+
+## D2 — Where the heartbeat toggle lives, and why it differs from the other two fields
+
+**Decision**: `heartbeat_enabled` is a new, **brief-only** field with no role heuristic. It is
+`None` (absent) unless the brief states it, and is emitted into the carrier only when set. Turns and
+concurrency, by contrast, always have a role-derived base value.
+
+**Rationale**: FR-005 / SC-004 — a heartbeat signal must appear only for agents the operator
+explicitly toggles, and for zero agents otherwise. There is no base heartbeat value to carry, so
+`None` must be representable and must render nothing. Making it a tri-state (`None` / `True` /
+`False`) keeps "off" distinct from "unstated."
+
+**Alternatives considered**:
+- *Default heartbeat to enabled and always emit it.* Rejected: that is an inferred default (a value
+  the operator did not state), which FR-007 forbids, and it would change today's output (breaks
+  SC-002).
+
+## D3 — Brief line grammar
+
+**Decision**: Run-policy overrides live in a new optional input-template section as free-text
+lines, one override per line, in the form:
+
+```
+<agent reference>: <clause>[, <clause>]...
+```
+
+where `<clause>` is one of (case-insensitive, tolerant of hyphen/space):
+- `max turns <N>` (aliases: `turns`, `max-turns`) — `N` a positive integer
+- `max concurrent <N>` (aliases: `concurrent`, `max-concurrent`, `concurrency`) — `N` a positive integer
+- `heartbeat <on|off>` (aliases for on: `on`, `enabled`, `true`; for off: `off`, `disabled`, `false`)
+
+`<agent reference>` is the text left of the first colon; it is slugified and boundary-matched to an
+agent's slug / title-slug / name-slug — the **same matcher** `parse_model_preferences` uses, so an
+operator names agents the way they already do for adapter preferences (FR-002).
+
+**Rationale**: Adapter preferences carry a single tier keyword and can slugify the whole line;
+run-policy carries three typed values, so it needs a reference-vs-values separator. A leading
+`reference:` colon is the least surprising delimiter and keeps the reference matcher reusable
+verbatim on the left side. Keyword clauses (not positional) keep partial statements natural (an
+operator can give just `heartbeat off`).
+
+**Alternatives considered**:
+- *Reuse the whole-line slug match like adapter, with values as trailing keywords.* Rejected:
+  ambiguous — a bare integer in a slugified line can't be attributed to turns vs concurrency.
+- *A structured YAML/JSON block in the brief.* Rejected: the brief is prose-shaped Markdown
+  (ADR-003); a structured block breaks the input-template idiom the parser is built around.
+
+## D4 — Split of validation: syntactic (error) vs semantic (warning)
+
+**Decision**:
+- **Syntactic** faults are rejected at **brief-validation time** (`BriefValidationError`, before any
+  generation): a non-positive / non-integer turns or concurrency value; an unrecognized clause
+  keyword; an unrecognized heartbeat state; the **same agent reference** stated twice with
+  conflicting values for a field. These need no knowledge of the generated agents.
+- **Semantic** faults are **advisory warnings** at render time via the existing `warn` sink: a
+  reference that matches **no** generated agent (FR-009), mirroring the adapter unmatched-preference
+  warning. Generation proceeds; no value is emitted for a non-existent agent.
+
+**Rationale**: The brief is validated before the (expensive) generation runs; catching malformed
+*values* there is cheap and honors "no malformed value reaches the bundle" (FR-010, SC-005). But
+whether a reference matches an agent depends on the *generated* org, which doesn't exist at brief-
+parse time — so unmatched is necessarily a render-time concern, and the established precedent
+(adapter) already treats it as a non-blocking warning, not an error (an org can legitimately differ
+from what the operator guessed).
+
+**Edge — two distinct references collide onto one agent with conflicting field values**: detectable
+only at match time. Handled deterministically: apply field overlays in brief line order; if a later
+matched line sets a field a different earlier-matched line already set to a different value for the
+same agent, emit a render-time warning naming the agent and field, and take the last write (stable,
+order-defined). This keeps determinism (FR-008) without failing the whole run on an ambiguity the
+operator may have intended (broad reference + a specific one).
+
+## D5 — Carrier key and shape
+
+**Decision**: Emit under each agent's existing `.paperclip.yaml` `runPolicy` block:
+
+```yaml
+runPolicy:
+  maxTurnsPerRun: <int>        # role-derived, or brief override
+  maxConcurrentRuns: <int>     # role-derived, or brief override
+  heartbeatEnabled: <bool>     # ONLY when the brief states it; omitted otherwise
+```
+
+The deployer maps `heartbeatEnabled` to its runtime heartbeat setting (private-repo, out of scope,
+FR-012), just as it already maps `maxTurnsPerRun` / `maxConcurrentRuns` (ADR-027).
+
+**Rationale**: One carrier for one per-agent concern (FR-011); additive to a block the validators
+already accept. `heartbeatEnabled` is a clear boolean name consistent with the existing camelCase
+keys.
+
+**Alternatives considered**:
+- *A separate top-level `heartbeat:` block.* Rejected: splits one per-agent concern across two
+  blocks; ADR-027 already argued for a single `runPolicy` block.
+
+## D6 — No new dependency, no schema churn
+
+**Decision**: Pure Python over existing libraries; no `pyproject.toml` change. The schema-shape
+validator is extended (not loosened) to assert `heartbeatEnabled`, when present, is a boolean, so a
+malformed emission is caught in-process before write (Constitution II).
+
+**Rationale**: Constitution "adding a dependency requires operator approval"; none is needed. The
+validator addition is a tightening, consistent with the NON-NEGOTIABLE schema-validity principle.

--- a/specs/014-run-policy-override/spec.md
+++ b/specs/014-run-policy-override/spec.md
@@ -1,0 +1,207 @@
+# Feature Specification: Per-agent run-policy override from the brief
+
+**Feature Branch**: `014-run-policy-override`
+
+**Created**: 2026-07-20
+
+**Status**: Draft
+
+**Input**: User description: "Per-agent run-policy override from the brief — the generator lets the operator's brief specify per-agent run-policy values (a maximum-turns-per-run cap, a maximum-concurrent-runs limit, and a heartbeat on/off toggle) and emits them into the bundle so the deployer applies them. Layers on top of the existing role-derived run-policy: a brief-specified value overrides the role-derived value for that agent and field. The heartbeat toggle is a new brief-only field emitted only when the brief states it. Adds no new defaults, heuristics, or inference — a pure carrier that passes brief-stated values through, following the per-agent budget precedent (a pure, deterministic, brief-driven renderer). Backward compatible: a brief with no run-policy values generates exactly what the generator produces today. Carrier/emit side only — the deployer that consumes it is out of scope."
+
+## Overview
+
+An agent wake with no bound on turns or concurrency can loop and burn budget before anything
+stops it. Today the generator emits per-agent run-policy caps that are chosen for the operator by
+a fixed role rule — the operator has no way to say "this specific agent should be bounded to N
+turns" or "do not run this agent on a heartbeat" from the brief. This feature gives the operator
+that direct control: the brief can state run-policy values for specific agents, and the generator
+carries those exact values into the bundle so the deployer applies them.
+
+The feature is a **pure carrier**. It does not decide what any value should be, does not infer
+values from company shape, role, or risk, and adds no defaults. It only passes through what the
+operator wrote. Where the brief is silent, the generator's existing behavior is untouched.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Bound a specific agent's turns and concurrency from the brief (Priority: P1)
+
+An operator authoring a company brief knows that one particular agent — say a research or
+watcher-style role — should never run more than a small number of turns per wake, and should not
+fan out into several concurrent runs. In the brief, the operator names that agent and states a
+maximum-turns-per-run and a maximum-concurrent-runs value. After generation, the bundle carries
+those exact values for that agent, overriding whatever value the generator would otherwise have
+emitted for it.
+
+**Why this priority**: This is the core of the feature — the operator's ability to bound turns and
+concurrency for named agents is the whole point (an unbounded wake can loop and burn budget). It is
+independently valuable and testable on its own, without the heartbeat toggle.
+
+**Independent Test**: Provide a brief that names one agent with an explicit turns cap and
+concurrency limit; generate the bundle; confirm that agent's emitted run-policy values equal the
+brief-stated values, and that every other agent's values are unchanged from a no-override run.
+
+**Acceptance Scenarios**:
+
+1. **Given** a brief that states a maximum-turns-per-run value for a named agent, **When** the
+   bundle is generated, **Then** that agent's emitted turns cap equals the brief-stated value and
+   is not the value the generator would otherwise have chosen.
+2. **Given** a brief that states a maximum-concurrent-runs value for a named agent, **When** the
+   bundle is generated, **Then** that agent's emitted concurrency limit equals the brief-stated
+   value.
+3. **Given** a brief that states a run-policy value for one agent only, **When** the bundle is
+   generated, **Then** every other agent's run-policy values are identical to what they would be
+   with no override in the brief.
+4. **Given** a brief that states a run-policy value referencing an agent that does not exist in the
+   generated company, **When** the bundle is generated, **Then** the operator is warned that the
+   reference matched no agent, and no run-policy value is invented for a non-existent agent.
+
+---
+
+### User Story 2 - Disable heartbeat for a specific agent from the brief (Priority: P2)
+
+An operator wants a specific agent to run only when it is explicitly given work, never on a
+recurring heartbeat wake. In the brief, the operator names that agent and sets its heartbeat to
+off. After generation, the bundle carries a heartbeat-disabled signal for that agent. For every
+agent the operator does not mention, nothing about heartbeat is emitted and behavior is unchanged.
+
+**Why this priority**: Valuable and operator-requested, but secondary to bounding turns/concurrency.
+Unlike turns/concurrency (which the generator already emits a base value for), heartbeat is a new
+brief-only signal, so it must be emitted only on explicit operator instruction and never implied.
+
+**Independent Test**: Provide a brief that sets heartbeat off for one named agent; generate the
+bundle; confirm a heartbeat-disabled signal appears for that agent and for no other agent, and that
+a brief which mentions no heartbeat produces no heartbeat signal anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** a brief that sets heartbeat off for a named agent, **When** the bundle is generated,
+   **Then** that agent carries a heartbeat-disabled signal in its run-policy.
+2. **Given** a brief that sets heartbeat on for a named agent, **When** the bundle is generated,
+   **Then** that agent carries a heartbeat-enabled signal in its run-policy.
+3. **Given** a brief that says nothing about heartbeat for any agent, **When** the bundle is
+   generated, **Then** no heartbeat signal is emitted for any agent, and behavior is unchanged.
+
+---
+
+### User Story 3 - A brief with no run-policy values changes nothing (Priority: P1)
+
+An operator who does not care about run-policy tuning writes a brief with no run-policy values at
+all. Generation produces exactly the bundle it produces today — byte-for-byte the same run-policy
+output as before this feature existed.
+
+**Why this priority**: Backward compatibility is a hard requirement and a release gate. It shares
+P1 with User Story 1 because a regression here silently changes every existing operator's output.
+
+**Independent Test**: Generate a bundle from a brief with no run-policy values, both before and
+after this feature; diff the two bundles; confirm they are identical.
+
+**Acceptance Scenarios**:
+
+1. **Given** a brief with no run-policy values, **When** the bundle is generated, **Then** the
+   emitted run-policy output is identical to the pre-feature output for the same brief.
+2. **Given** a brief with no run-policy values, **When** the bundle is generated, **Then** no
+   heartbeat signal is emitted for any agent (there is no base heartbeat behavior to carry).
+
+---
+
+### Edge Cases
+
+- **Reference matches multiple agents**: a brief line whose agent reference legitimately names more
+  than one agent applies the stated values to each matched agent (mirrors how existing per-role
+  brief overrides fan out). The most-specific match wins when one reference nests inside another.
+- **Partial value set for one agent**: a brief that states only a turns cap for an agent (and not a
+  concurrency limit) overrides only turns; the un-stated field keeps its existing generator-chosen
+  value. Fields are independent.
+- **Out-of-range or non-numeric value**: a stated value that is not a usable positive whole number
+  (for turns/concurrency) is rejected at brief-validation time with a clear message, rather than
+  silently emitting a broken bundle.
+- **Same agent referenced twice with conflicting values**: the brief is reported as ambiguous at
+  validation time rather than one line silently winning.
+- **Reference matches no agent**: reported as a non-blocking warning naming the unmatched
+  reference (mirrors the existing unmatched-override warning); generation still proceeds.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The brief MUST provide a channel through which the operator can state, for a named
+  agent, any subset of three run-policy values: a maximum-turns-per-run cap, a maximum-concurrent-
+  runs limit, and a heartbeat on/off toggle.
+- **FR-002**: An agent named in the brief MUST be resolved to a generated agent by the same
+  boundary-safe reference matching already used for per-role brief overrides (matching against the
+  agent's slug, title, and name), so the operator can name agents without knowing generated slugs.
+- **FR-003**: A brief-stated maximum-turns-per-run value MUST override, for the referenced agent,
+  the turns value the generator would otherwise emit; a brief-stated maximum-concurrent-runs value
+  MUST likewise override the concurrency value for that agent.
+- **FR-004**: The three run-policy fields MUST be independent: stating one field for an agent MUST
+  NOT change the other fields for that agent.
+- **FR-005**: The heartbeat toggle MUST be emitted for an agent only when the brief explicitly
+  states it for that agent; when the brief says nothing about heartbeat, no heartbeat signal is
+  emitted for any agent.
+- **FR-006**: When the brief states no run-policy values at all, the generated bundle MUST be
+  identical to what the generator produces today for the same brief (no new fields, no changed
+  values, no heartbeat signal).
+- **FR-007**: The feature MUST NOT introduce any default, heuristic, or inference that chooses a
+  run-policy value from company shape, role, risk, or any signal — it emits only values the
+  operator stated. (Existing role-derived turns/concurrency values remain the base and are
+  unchanged by this feature; this feature only overrides them where the brief speaks.)
+- **FR-008**: The derivation from brief to emitted values MUST be deterministic and free of any
+  model call or external I/O — the same brief always yields the same run-policy output.
+- **FR-009**: A brief run-policy value that references an agent matching no generated agent MUST
+  produce a non-blocking warning that names the unmatched reference; generation proceeds and no
+  value is emitted for a non-existent agent.
+- **FR-010**: A brief run-policy value that is malformed (a turns or concurrency value that is not a
+  usable positive whole number, an unrecognized heartbeat state, or the same agent given
+  conflicting values) MUST be rejected at brief-validation time with a message identifying the
+  problem, before any generation work is done.
+- **FR-011**: The emitted run-policy values MUST travel in the bundle's existing per-agent run-
+  policy carrier alongside the role-derived turns and concurrency values, so the deployer consumes
+  them through one carrier.
+- **FR-012**: The scope of this feature is the emit/carrier side only; how the deployer applies the
+  emitted values (including the heartbeat toggle) is out of scope and lives outside this repository.
+- **FR-013**: The input template MUST document the run-policy channel — the three values, that they
+  are optional, that they name specific agents, and that omitting them leaves behavior unchanged —
+  so an operator can discover and use it without reading code.
+
+### Key Entities *(include if feature involves data)*
+
+- **Run-policy override**: an operator-stated, per-agent set of up to three optional values —
+  maximum turns per run, maximum concurrent runs, heartbeat on/off — attached to a named agent
+  reference. Absent for any agent the operator does not mention.
+- **Resolved per-agent run policy**: the values actually emitted for an agent — the existing role-
+  derived turns and concurrency values, with any brief-stated value substituted in, plus a
+  heartbeat signal only when the operator stated one.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: For a brief that states run-policy values for a named agent, 100% of the stated
+  values appear unchanged on that agent in the generated bundle.
+- **SC-002**: For a brief with no run-policy values, the generated bundle is byte-for-byte
+  identical to the pre-feature output for the same brief (zero diff).
+- **SC-003**: Stating a run-policy value for one agent changes the run-policy output of zero other
+  agents.
+- **SC-004**: A heartbeat signal appears in the bundle only for agents the operator explicitly set
+  it on, and for zero agents otherwise.
+- **SC-005**: Every malformed run-policy value in a brief is reported at validation time; zero
+  malformed values reach the generated bundle.
+- **SC-006**: An operator can discover and correctly use the run-policy channel from the input
+  template alone, without reading source code.
+
+## Assumptions
+
+- The brief expresses per-agent run-policy values through free-text override lines that name an
+  agent, following the established per-role override convention (the same channel and boundary-safe
+  matching used for adapter/model preferences). The exact line grammar is an implementation detail
+  resolved in planning; this spec fixes only the operator-visible behavior.
+- "What the generator produces today" is the current `main` output, in which the existing role rule
+  emits a turns cap and concurrency limit for every agent. This feature layers over that base; it
+  does not remove or alter the base rule.
+- The bundle already has a per-agent run-policy carrier (turns and concurrency). Adding the
+  heartbeat toggle extends that carrier with one optional field; the field is absent unless the
+  operator states it.
+- Choosing *appropriate* run-policy values (by role, risk, or company shape) is deliberately out of
+  scope for this repository. This feature only transports operator-stated values.
+- The deployer that reads the emitted run-policy and applies it (including mapping the heartbeat
+  toggle to runtime behavior) lives outside this repository and is unchanged by this work.

--- a/specs/014-run-policy-override/tasks.md
+++ b/specs/014-run-policy-override/tasks.md
@@ -1,0 +1,192 @@
+---
+description: "Task list for feature 014 — per-agent run-policy override from the brief"
+---
+
+# Tasks: Per-agent run-policy override from the brief
+
+**Input**: Design documents from `specs/014-run-policy-override/`
+
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/run-policy-override.md
+
+**Tests**: REQUIRED. Constitution III mandates test-first (red-green-refactor) for non-trivial logic
+(parser, merge, brief validation). Every implementation task is preceded by a failing test task.
+
+**Organization**: Grouped by user story. US1 and US3 are Priority P1; US2 is P2.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependency on an unfinished task)
+- **[Story]**: US1 / US2 / US3, or `Foundation` for shared prerequisites
+- All paths are relative to repo root
+
+---
+
+## Phase 1: Setup & Baseline
+
+**Purpose**: Pin "today's" output before any code changes, so the backward-compat gate (US3, T022)
+has an honest reference.
+
+- [ ] T001 [Foundation] Capture the pre-change baseline: pick a representative multi-agent fixture
+  brief with **no** run-policy values (reuse an existing fixture in `tests/` if one covers ≥1 root +
+  ≥1 non-root + a poller-titled agent; otherwise add one). Generate its `.paperclip.yaml` on the
+  **current, unmodified** generator and save the exact `runPolicy` blocks as the golden reference
+  used by T022. Record it as a committed fixture (e.g. `tests/fixtures/runpolicy_baseline.yaml` or an
+  inline constant in the US3 test). MUST be done first, before any source is touched (T003 onward).
+
+**Checkpoint**: baseline recorded; safe to modify source.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared model/brief surface every story builds on. All backward-compatible (new fields
+default to absent).
+
+- [ ] T002 [P] [Foundation] Failing test: `RunPolicy` accepts optional `heartbeat_enabled` (default
+  `None`); a two-arg `RunPolicy(max_turns_per_run=.., max_concurrent_runs=..)` still constructs and
+  has `heartbeat_enabled is None`. `tests/test_run_policy.py`
+- [ ] T003 [Foundation] Add `heartbeat_enabled: bool | None = None` to the `RunPolicy` dataclass.
+  `src/paperclip_blueprints/renderers/run_policy.py` (depends on T002)
+- [ ] T004 [P] [Foundation] Failing test: `RunPolicyOverride` frozen dataclass with three optional
+  fields, all defaulting to `None`. `tests/test_run_policy.py`
+- [ ] T005 [Foundation] Add the `RunPolicyOverride` dataclass. `renderers/run_policy.py` (T004)
+- [ ] T006 [P] [Foundation] Failing test: `parse_brief` reads a new "Run-policy overrides" section
+  into `CompanyBrief.run_policy_preferences: list[str] | None`; absent/blank section ⇒ `None`; a
+  brief with no such section is unchanged in every other field. `tests/test_models.py`
+- [ ] T007 [Foundation] Add `run_policy_preferences: list[str] | None = None` to `CompanyBrief` and
+  parse the new section. `src/paperclip_blueprints/models/input.py` (T006)
+- [ ] T008 [P] [Foundation] Failing test: syntactic validation (FR-010) raises `BriefValidationError`
+  for — non-positive / non-integer turns or concurrency; unknown clause keyword; unknown heartbeat
+  token; a line with no clause; the **same reference** given conflicting values for one field. All
+  problems reported together. `tests/test_models.py`
+- [ ] T009 [Foundation] Implement the syntactic validation in brief parsing/validation.
+  `models/input.py` (T008). No agent knowledge here — value/shape checks only.
+
+**Checkpoint**: model + brief foundation ready; stories can proceed.
+
+---
+
+## Phase 3: User Story 1 — Bound turns/concurrency for a named agent (Priority: P1) 🎯 MVP
+
+**Goal**: A brief line naming an agent with `max turns` / `max concurrent` puts those exact values
+on that agent in `.paperclip.yaml`, overriding the role-derived value per field; other agents
+unchanged; an unmatched reference warns and is skipped.
+
+**Independent Test**: Generate from a brief overriding one agent's turns+concurrency; assert that
+agent's emitted values equal the stated values and every other agent equals a no-override run.
+
+- [ ] T010 [P] [US1] Failing test: `parse_run_policy_preferences(lines, agents)` maps turns/
+  concurrency clauses to per-slug `RunPolicyOverride`; boundary-safe reference matching (a line for
+  `analyst` does not match `senior-analyst`); a reference matching several agents fans out; returns
+  `unmatched` for a reference hitting no agent; `(None, agents) → ({}, [])`. `tests/test_run_policy.py`
+- [ ] T011 [US1] Implement `parse_run_policy_preferences`, reusing `adapter._matched_ref` /
+  `_boundary_contains`. `renderers/run_policy.py` (T010). Assumes lines already syntactically valid.
+- [ ] T012 [P] [US1] Failing test: `assign_run_policies(agents, overrides)` overlays each **set**
+  override field onto the ADR-027 role base; an unset field keeps the base; overriding one agent
+  leaves all others identical to `assign_run_policies(agents)`. `tests/test_run_policy.py`
+- [ ] T013 [US1] Add optional `overrides` param to `assign_run_policies` and apply the per-field
+  overlay. `renderers/run_policy.py` (T012). Default `None` ⇒ identical to today (guards T022).
+- [ ] T014 [US1] Wire `render.py`: parse `brief.run_policy_preferences`, pass overrides into
+  `assign_run_policies`, and surface each unmatched reference via the `warn` sink (message per the
+  contract), mirroring the adapter unmatched-preference warning. `renderers/render.py` (T011, T013)
+- [ ] T015 [P] [US1] Failing test at the render path: a brief overriding one agent's turns+
+  concurrency emits those values under that agent's `runPolicy`; other agents unchanged; an
+  unmatched-reference line raises a warning through `warn`. `tests/test_render.py` (T014)
+
+**Checkpoint**: US1 fully functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 — Disable heartbeat for a named agent (Priority: P2)
+
+**Goal**: A brief line setting `heartbeat off`/`on` for an agent emits `runPolicy.heartbeatEnabled`
+for that agent only; nothing is emitted for any agent the operator doesn't mention.
+
+**Independent Test**: Generate from a brief setting heartbeat off for one agent; assert
+`heartbeatEnabled: false` appears for it and for no other agent; a brief mentioning no heartbeat
+emits the key nowhere.
+
+- [ ] T016 [P] [US2] Failing test: `parse_run_policy_preferences` recognizes heartbeat tokens
+  (`on`/`enabled`/`true`, `off`/`disabled`/`false`) → `override.heartbeat_enabled`, and
+  `assign_run_policies` carries it onto the resolved `RunPolicy`; it stays `None` for unmentioned
+  agents. `tests/test_run_policy.py`
+- [ ] T017 [US2] Extend the parser (heartbeat clause recognition) and the merge to carry
+  `heartbeat_enabled`. `renderers/run_policy.py` (T016)
+- [ ] T018 [P] [US2] Failing test: `paperclip_yaml.j2` emits `heartbeatEnabled: <true|false>`
+  (lower-cased) **only** when `heartbeat_enabled is not None`, and omits the key entirely when
+  `None`. `tests/test_render.py`
+- [ ] T019 [US2] Add the conditional `heartbeatEnabled` line to the `runPolicy` block.
+  `src/paperclip_blueprints/templates/paperclip_yaml.j2` (T018)
+- [ ] T020 [P] [US2] Failing test: `schema_shape` validator accepts a boolean `heartbeatEnabled` and
+  fails a non-boolean, blocking the write (Constitution II). `tests/test_validators.py`
+- [ ] T021 [US2] Extend the schema-shape validator to assert `runPolicy.heartbeatEnabled`, when
+  present, is boolean. `src/paperclip_blueprints/validators/schema_shape.py` (T020)
+
+**Checkpoint**: US2 functional; US1 + US2 both work independently.
+
+---
+
+## Phase 5: User Story 3 — A brief with no run-policy values changes nothing (Priority: P1)
+
+**Goal**: The backward-compat guarantee, held as its **own** explicitly-tested gate — the one most
+likely to erode quietly once overrides and the heartbeat tri-state exist.
+
+**Independent Test**: Diff a no-override generation against the T001 baseline — zero diff.
+
+- [ ] T022 [US3] **Backward-compat gate (standalone — do NOT fold into any other assertion).**
+  Failing-then-passing test: generating from a brief with **no** `run_policy_preferences` produces a
+  `.paperclip.yaml` **byte-identical** to the T001 baseline. The test MUST assert both:
+  (a) every agent's `maxTurnsPerRun` / `maxConcurrentRuns` equals the baseline (role rule untouched);
+  (b) **no `heartbeatEnabled` key appears for any agent** — the tri-state `None` renders nothing.
+  Give it its own test function whose name states the guarantee (e.g.
+  `test_no_run_policy_prefs_is_byte_identical_to_baseline`). `tests/test_run_policy_backcompat.py`
+  (depends on US1 + US2 complete so the tri-state template path exists to be exercised)
+- [ ] T023 [US3] Run the full existing suite and confirm zero behavioral drift for bundles that
+  state no run-policy values (existing render/bundle/golden tests still green). `uv run pytest -q`
+
+**Checkpoint**: the erosion-guard gate is locked; all three stories independently pass.
+
+---
+
+## Phase 6: Polish, Docs & Gates
+
+- [ ] T024 [P] Add the "Run-policy overrides (optional)" section to `examples/input-template.md`
+  (FR-013) using the text in `contracts/run-policy-override.md` §6 — three values, optional, names
+  agents, blank ⇒ unchanged. Keep the section number consistent with the existing template ordering.
+- [ ] T025 [P] Walk through `quickstart.md` end-to-end (operator path): write an override, generate,
+  see it in `.paperclip.yaml`; blank section ⇒ no change. Fix any drift between doc and behavior.
+- [ ] T026 Final gates: `uv run ruff check .` **and** `uv run ruff format --check .` **and**
+  `uv run pyright` all clean (ruff format is an explicit end-session gate, not just ruff check).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase order
+- **T001 (baseline) MUST be first** — it captures unmodified output; any earlier source edit
+  corrupts the reference.
+- **Phase 2 (Foundational)** blocks all stories.
+- **US1 (Phase 3)** and **US2 (Phase 4)** depend only on Foundational. They edit the same
+  `run_policy.py` parser/merge, so if worked concurrently, serialize T011/T013 against T017.
+- **US3 (Phase 5, T022)** depends on US1 **and** US2 — the byte-identical test must exercise the
+  tri-state template path. This is the standalone backward-compat gate.
+- **Phase 6** depends on all stories complete.
+
+### Within each story
+- Test task (failing) precedes its implementation task — always.
+- Parser (T011) before the merge wiring uses it; merge (T013) before render wiring (T014); render
+  wiring before the render-path test passes (T015).
+
+### Parallel opportunities
+- T002 / T004 / T006 / T008 (Foundational tests, different concerns) can be written in parallel.
+- Across stories: US1 and US2 test-writing can start together once Foundational is green.
+- T024 / T025 (docs) run in parallel at the end.
+
+## Notes
+
+- Task IDs are sequential T001–T026 with no gaps; US3's standalone backward-compat gate is T022.
+- Keep the feature a **pure carrier**: no defaults, no heuristics, no inference of values from role
+  or company shape (FR-007). The parser reads only stated tokens.
+- Commit is the operator's call — do not auto-commit between tasks.
+- The single highest-value invariant is T022: a silent regression there re-prices every existing
+  operator's bundle. Treat a failure of T022 as release-blocking.

--- a/src/paperclip_blueprints/models/input.py
+++ b/src/paperclip_blueprints/models/input.py
@@ -73,6 +73,12 @@ class CompanyBrief(BaseModel):
     capital_monthly_eur: int | None = None
     capital_setup_eur: int | None = None
     adapter_preferences: list[str] | None = None
+    run_policy_preferences: list[str] | None = None
+    """Section-12 optional per-agent run-policy override lines (feature 014 / ADR-034), e.g.
+    ``"research-analyst: max turns 8, heartbeat off"``. Free-text, one override per line,
+    naming an agent and any of max turns / max concurrent / heartbeat on|off. ``None`` ⇒ the
+    role-derived caps stand unchanged. Values are validated here; agent matching happens at
+    render time."""
     free_text: str | None = None
 
     @field_validator("name", "description", "north_star", "we_are")
@@ -148,6 +154,47 @@ class CompanyBrief(BaseModel):
             raise ValueError(
                 f"unknown use-case pattern {v!r}; available: {', '.join(KNOWN_PATTERNS)}"
             )
+        return v
+
+    @field_validator("run_policy_preferences")
+    @classmethod
+    def _valid_run_policy_lines(cls, v: list[str] | None) -> list[str] | None:
+        """Syntactic validation of run-policy override lines (feature 014, FR-010).
+
+        Rejects a malformed value (non-positive / non-integer turns or concurrency, unknown
+        clause or heartbeat token, a line with no clause/agent) and the same reference given
+        conflicting values for one field. No agent knowledge here — matching is a render
+        concern. Imported locally so the model stays loadable without the renderers package.
+        """
+        if not v:
+            return v
+        # Local import (mirrors the KNOWN_PATTERNS pattern) — models depend on renderers only
+        # for this pure, shared line parser; no runtime cycle (run_policy imports models only
+        # under TYPE_CHECKING).
+        from ..renderers.run_policy import parse_run_policy_line
+
+        errors: list[str] = []
+        by_ref: dict[str, dict[str, object]] = {}
+        for line in v:
+            try:
+                ref, override = parse_run_policy_line(line)
+            except ValueError as exc:
+                errors.append(str(exc))
+                continue
+            prior = by_ref.setdefault(slugify_project_name(ref), {})
+            for field in ("max_turns_per_run", "max_concurrent_runs", "heartbeat_enabled"):
+                new = getattr(override, field)
+                if new is None:
+                    continue
+                if field in prior and prior[field] != new:
+                    errors.append(
+                        f"run-policy override for {ref!r} sets {field} to conflicting "
+                        f"values ({prior[field]!r} then {new!r})"
+                    )
+                else:
+                    prior[field] = new
+        if errors:
+            raise ValueError("; ".join(errors))
         return v
 
 
@@ -304,6 +351,8 @@ def parse_brief(markdown: str) -> CompanyBrief:
         data["adapter_preferences"] = overrides
     if (v := _anchored_block(sec.get(11, ""), "other context")) is not None:
         data["free_text"] = v
+    if rp := _list_items(_anchored_block(sec.get(12, ""), "overrides")):
+        data["run_policy_preferences"] = rp
 
     data = {k: v for k, v in data.items() if v is not None}
 

--- a/src/paperclip_blueprints/renderers/render.py
+++ b/src/paperclip_blueprints/renderers/render.py
@@ -25,7 +25,7 @@ from .adapter import assign_adapters, parse_model_preferences
 from .budget import allocate_budgets
 from .frontmatter import dump_frontmatter
 from .routines import RoutineSpec, derive_routines
-from .run_policy import assign_run_policies
+from .run_policy import assign_run_policies, parse_run_policy_preferences
 
 _TEMPLATES_DIR = Path(__file__).resolve().parent.parent / "templates"
 
@@ -287,6 +287,17 @@ def render_files(
                 "that role keeps its default model"
             )
 
+    # Per-agent run-policy overrides from the brief (feature 014 / ADR-034): a pure carrier
+    # layering brief-stated caps / heartbeat toggle over the ADR-027 role base. Empty ⇒ the
+    # role base alone (byte-identical to today). Values are brief-validated; a reference that
+    # matches no agent is advisory only.
+    run_overrides, run_unmatched = parse_run_policy_preferences(
+        config.brief.run_policy_preferences, config.agents
+    )
+    if warn is not None:
+        for line in run_unmatched:
+            warn(f"run-policy override {line!r} names no agent — no run policy is set for it")
+
     # Tasks with a `recurrence` cadence → importable Routines (ADR-022, US3, PROVISIONAL cron):
     # a `.paperclip.yaml` routines.<task-slug> block; the recurring task itself is flagged
     # `recurring: true` (no shadow task). Empty when no task is scheduled.
@@ -308,9 +319,9 @@ def render_files(
         "license_kind": config.license_kind,
         "budgets": allocation.cents,
         "adapters": adapters,
-        # Per-agent run-policy caps (ADR-027): bundle-driven maxTurnsPerRun /
-        # maxConcurrentRuns reasoned from role, defaults matching the deployer's.
-        "run_policies": assign_run_policies(config.agents),
+        # Per-agent run-policy caps (ADR-027): role-derived maxTurnsPerRun /
+        # maxConcurrentRuns, with brief overrides overlaid per field (feature 014 / ADR-034).
+        "run_policies": assign_run_policies(config.agents, run_overrides),
         "routines": routines,
     }
 

--- a/src/paperclip_blueprints/renderers/run_policy.py
+++ b/src/paperclip_blueprints/renderers/run_policy.py
@@ -18,11 +18,16 @@ bounded poller gets low turns).
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from ..paperclip_slug import slugify_project_name
+from .adapter import _matched_ref
+
 if TYPE_CHECKING:
     from ..models.agent import AgentDefinition
+    from .adapter import _AgentRef
 
 # Deployer-matching defaults: unchanged behavior unless a role tightens them.
 DEFAULT_MAX_TURNS_PER_RUN = 30
@@ -44,10 +49,29 @@ _POLLER_RE = re.compile(
 
 @dataclass(frozen=True)
 class RunPolicy:
-    """One agent's run-policy caps, emitted under ``.paperclip.yaml`` ``runPolicy``."""
+    """One agent's run-policy caps, emitted under ``.paperclip.yaml`` ``runPolicy``.
+
+    ``heartbeat_enabled`` is a brief-only field (feature 014 / ADR-034) with no role
+    heuristic: it is ``None`` (⇒ nothing emitted) unless a brief override sets it.
+    """
 
     max_turns_per_run: int
     max_concurrent_runs: int
+    heartbeat_enabled: bool | None = None
+
+
+@dataclass(frozen=True)
+class RunPolicyOverride:
+    """Operator-stated run-policy values for one agent, parsed from a brief line (ADR-034).
+
+    Every field is optional; a ``None`` field means the brief did not state it, so the
+    role-derived base value is kept for that field (``heartbeat_enabled`` has no base — it
+    stays ``None`` and nothing is emitted).
+    """
+
+    max_turns_per_run: int | None = None
+    max_concurrent_runs: int | None = None
+    heartbeat_enabled: bool | None = None
 
 
 def derive_run_policy(*, is_root: bool, title: str, mandate: str) -> RunPolicy:
@@ -69,9 +93,188 @@ def derive_run_policy(*, is_root: bool, title: str, mandate: str) -> RunPolicy:
     return RunPolicy(max_turns_per_run=max_turns, max_concurrent_runs=max_concurrent)
 
 
-def assign_run_policies(agents: list[AgentDefinition]) -> dict[str, RunPolicy]:
-    """Return each agent's reasoned ``RunPolicy``, keyed by slug (ADR-027)."""
-    return {
-        a.slug: derive_run_policy(is_root=a.reports_to is None, title=a.title, mandate=a.mandate)
-        for a in agents
-    }
+def assign_run_policies(
+    agents: list[AgentDefinition],
+    overrides: dict[str, RunPolicyOverride] | None = None,
+) -> dict[str, RunPolicy]:
+    """Return each agent's ``RunPolicy``, keyed by slug: the role-derived base (ADR-027)
+    with any brief overrides overlaid per field (feature 014 / ADR-034).
+
+    Args:
+        agents: the generated agents.
+        overrides: slug -> :class:`RunPolicyOverride` from the brief (see
+            :func:`parse_run_policy_preferences`). ``None``/empty ⇒ output identical to the
+            pure role rule, so a bundle with no run-policy values is byte-identical to today.
+
+    Returns:
+        slug -> :class:`RunPolicy`. For an agent with an override, each **set** field replaces
+        the role-derived value; an unset field keeps the base. ``heartbeat_enabled`` comes only
+        from the override (the base is ``None``).
+    """
+    ov_map = overrides or {}
+    result: dict[str, RunPolicy] = {}
+    for a in agents:
+        base = derive_run_policy(is_root=a.reports_to is None, title=a.title, mandate=a.mandate)
+        ov = ov_map.get(a.slug)
+        if ov is None:
+            result[a.slug] = base
+        else:
+            result[a.slug] = RunPolicy(
+                max_turns_per_run=(
+                    ov.max_turns_per_run
+                    if ov.max_turns_per_run is not None
+                    else base.max_turns_per_run
+                ),
+                max_concurrent_runs=(
+                    ov.max_concurrent_runs
+                    if ov.max_concurrent_runs is not None
+                    else base.max_concurrent_runs
+                ),
+                heartbeat_enabled=ov.heartbeat_enabled,
+            )
+    return result
+
+
+# --- brief-driven override layer (feature 014 / ADR-034) ---------------------
+#
+# A pure carrier: it transports operator-stated values and infers nothing. Clause keywords
+# (with aliases), matched case-insensitively; turns/concurrency take a positive integer;
+# heartbeat takes an on/off token.
+_TURNS_RE = re.compile(r"^(?:max[\s-]*turns|turns)\s+(.+)$")
+_CONCURRENT_RE = re.compile(r"^(?:max[\s-]*concurrent|concurrency|concurrent)\s+(.+)$")
+_HEARTBEAT_RE = re.compile(r"^heartbeat\s+(.+)$")
+_HEARTBEAT_ON = {"on", "enabled", "true"}
+_HEARTBEAT_OFF = {"off", "disabled", "false"}
+
+
+def _positive_int(raw: str, ref: str, label: str) -> int:
+    s = raw.strip()
+    if not re.fullmatch(r"\d+", s):
+        raise ValueError(
+            f"run-policy override for {ref!r} has a non-integer {label} value {raw.strip()!r}"
+        )
+    val = int(s)
+    if val < 1:
+        raise ValueError(
+            f"run-policy override for {ref!r} {label} must be a positive integer, got {val}"
+        )
+    return val
+
+
+def parse_run_policy_line(line: str) -> tuple[str, RunPolicyOverride]:
+    """Parse one brief override line ``<agent reference>: <clause>[, <clause>]...``.
+
+    Returns ``(reference, override)`` where ``reference`` is the raw text before the first
+    colon (matched to agents later). Raises :class:`ValueError` on any malformed line — a
+    missing colon or reference, no clause, a non-positive/non-integer turns/concurrency value,
+    an unknown clause keyword, an unknown heartbeat token, or one field set twice with
+    conflicting values in the same line. Does no agent matching (that needs the generated org).
+    """
+    if ":" not in line:
+        raise ValueError(
+            f"run-policy override {line!r} must name an agent before ':', e.g. 'ceo: max turns 8'"
+        )
+    ref, _, rest = line.partition(":")
+    ref = ref.strip()
+    if not ref:
+        raise ValueError(f"run-policy override {line!r} is missing an agent name before ':'")
+    clauses = [c.strip() for c in rest.split(",") if c.strip()]
+    if not clauses:
+        raise ValueError(f"run-policy override for {ref!r} states no value")
+
+    max_turns: int | None = None
+    max_concurrent: int | None = None
+    heartbeat: bool | None = None
+    for clause in clauses:
+        cl = clause.lower()
+        if m := _TURNS_RE.match(cl):
+            val = _positive_int(m.group(1), ref, "max turns")
+            if max_turns is not None and max_turns != val:
+                raise ValueError(
+                    f"run-policy override for {ref!r} sets 'max turns' twice with "
+                    "conflicting values"
+                )
+            max_turns = val
+        elif m := _CONCURRENT_RE.match(cl):
+            val = _positive_int(m.group(1), ref, "max concurrent")
+            if max_concurrent is not None and max_concurrent != val:
+                raise ValueError(
+                    f"run-policy override for {ref!r} sets 'max concurrent' twice with "
+                    "conflicting values"
+                )
+            max_concurrent = val
+        elif m := _HEARTBEAT_RE.match(cl):
+            tok = m.group(1).strip()
+            if tok in _HEARTBEAT_ON:
+                hb = True
+            elif tok in _HEARTBEAT_OFF:
+                hb = False
+            else:
+                raise ValueError(
+                    f"run-policy override for {ref!r} has an unrecognized heartbeat state "
+                    f"{tok!r} (use on/off)"
+                )
+            if heartbeat is not None and heartbeat != hb:
+                raise ValueError(
+                    f"run-policy override for {ref!r} sets 'heartbeat' twice with "
+                    "conflicting values"
+                )
+            heartbeat = hb
+        else:
+            raise ValueError(
+                f"run-policy override for {ref!r} has an unrecognized clause {clause!r} "
+                "(use 'max turns <n>', 'max concurrent <n>', or 'heartbeat on|off')"
+            )
+    return ref, RunPolicyOverride(
+        max_turns_per_run=max_turns,
+        max_concurrent_runs=max_concurrent,
+        heartbeat_enabled=heartbeat,
+    )
+
+
+def _merge_override(a: RunPolicyOverride | None, b: RunPolicyOverride) -> RunPolicyOverride:
+    """Field-wise merge of two overrides for one agent; ``b`` (later line) wins where set."""
+    if a is None:
+        return b
+    return RunPolicyOverride(
+        max_turns_per_run=(
+            b.max_turns_per_run if b.max_turns_per_run is not None else a.max_turns_per_run
+        ),
+        max_concurrent_runs=(
+            b.max_concurrent_runs if b.max_concurrent_runs is not None else a.max_concurrent_runs
+        ),
+        heartbeat_enabled=(
+            b.heartbeat_enabled if b.heartbeat_enabled is not None else a.heartbeat_enabled
+        ),
+    )
+
+
+def parse_run_policy_preferences(
+    preferences: Sequence[str] | None,
+    agents: Sequence[_AgentRef],
+) -> tuple[dict[str, RunPolicyOverride], list[str]]:
+    """Resolve the brief's run-policy override lines to per-slug overrides (ADR-034).
+
+    Each line is parsed (assumed already syntactically valid — the brief validator checks that)
+    and its reference matched boundary-safe to agents by slug / title-slug / name-slug, reusing
+    the adapter matcher so operators name agents the same way as for model preferences. A
+    reference matching several agents fans out; distinct lines matching one agent merge
+    field-wise in line order (later wins).
+
+    Returns ``(overrides, unmatched)`` — ``overrides`` maps slug -> :class:`RunPolicyOverride`;
+    ``unmatched`` lists lines whose reference matched no agent (the caller warns).
+    """
+    if not preferences:
+        return {}, []
+    overrides: dict[str, RunPolicyOverride] = {}
+    unmatched: list[str] = []
+    for line in preferences:
+        ref, ov = parse_run_policy_line(line)
+        line_slug = slugify_project_name(ref)
+        matched = [a.slug for a in agents if _matched_ref(a, line_slug)]
+        if not matched:
+            unmatched.append(line)
+            continue
+        for slug in matched:
+            overrides[slug] = _merge_override(overrides.get(slug), ov)
+    return overrides, unmatched

--- a/src/paperclip_blueprints/templates/paperclip_yaml.j2
+++ b/src/paperclip_blueprints/templates/paperclip_yaml.j2
@@ -23,6 +23,9 @@ agents:
     runPolicy:
       maxTurnsPerRun: {{ run_policies[a.slug].max_turns_per_run }}
       maxConcurrentRuns: {{ run_policies[a.slug].max_concurrent_runs }}
+{% if run_policies[a.slug].heartbeat_enabled is not none %}
+      heartbeatEnabled: {{ run_policies[a.slug].heartbeat_enabled | lower }}
+{% endif %}
 {% endif %}
 {% endfor %}
 {% if projects %}

--- a/src/paperclip_blueprints/validators/schema_shape.py
+++ b/src/paperclip_blueprints/validators/schema_shape.py
@@ -126,6 +126,10 @@ def check_schema_shape(config: CompanyConfig, files: dict[str, str]) -> list[str
     # credentials stay operator-environment).
     v += _check_adapter_fields(files.get(".paperclip.yaml", ""))
 
+    # S16 (feature 014 / ADR-034): any per-agent runPolicy.heartbeatEnabled is a boolean —
+    # a non-boolean would be rejected at import; catch it in-process before write.
+    v += _check_run_policy_fields(files.get(".paperclip.yaml", ""))
+
     # S14 (ADR-022): the hiring board-gate ships as a structured, importable company setting.
     if "requireBoardApprovalForNewAgents: true" not in files.get(".paperclip.yaml", ""):
         v.append(
@@ -273,6 +277,33 @@ def _check_adapter_fields(yaml_text: str) -> list[str]:
             v.append(
                 f"S12: agent {slug!r} adapter.config.env must not be emitted "
                 f"(provider routing/base URLs/credentials stay operator-environment)"
+            )
+    return v
+
+
+def _check_run_policy_fields(yaml_text: str) -> list[str]:
+    """S16 (ADR-034): every emitted ``runPolicy.heartbeatEnabled`` is a boolean.
+
+    The turns/concurrency caps are role-derived integers (ADR-027); only the brief-driven
+    heartbeat toggle can carry an operator-shaped value, so it is the one field checked here.
+    """
+    if not yaml_text or "runPolicy" not in yaml_text:
+        return []
+    try:
+        data = YAML(typ="safe").load(yaml_text)
+    except Exception:  # noqa: BLE001 - I9 reports unparseable YAML; don't double-fault
+        return []
+    v: list[str] = []
+    for slug, agent in (data.get("agents") or {}).items():
+        if not isinstance(agent, dict) or not isinstance(agent.get("runPolicy"), dict):
+            continue
+        run_policy = agent["runPolicy"]
+        if "heartbeatEnabled" in run_policy and not isinstance(
+            run_policy["heartbeatEnabled"], bool
+        ):
+            v.append(
+                f"S16: agent {slug!r} runPolicy.heartbeatEnabled must be a boolean, "
+                f"got {run_policy['heartbeatEnabled']!r}"
             )
     return v
 

--- a/tests/fixtures/runpolicy_baseline.paperclip.yaml
+++ b/tests/fixtures/runpolicy_baseline.paperclip.yaml
@@ -1,0 +1,26 @@
+schema: paperclip/v1
+company:
+  requireBoardApprovalForNewAgents: true
+sidebar:
+  agents: [ceo, engineer]
+  projects: [launch-v1]
+agents:
+  ceo:
+    role: ceo
+    adapter:
+      type: claude_local
+      config:
+        model: claude-opus-4-8
+    runPolicy:
+      maxTurnsPerRun: 30
+      maxConcurrentRuns: 1
+  engineer:
+    adapter:
+      type: claude_local
+      config:
+        model: claude-sonnet-4-6
+    runPolicy:
+      maxTurnsPerRun: 30
+      maxConcurrentRuns: 2
+projects:
+  launch-v1:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -252,6 +252,75 @@ def test_parse_aggregates_all_errors() -> None:
     assert "north" in messages.lower()
 
 
+# --- run-policy override channel (feature 014) ------------------------------
+
+_RUN_POLICY_SECTION = """
+
+## 12. Run-policy overrides (optional)
+
+**Your overrides:**
+
+- engineer: max turns 8, heartbeat off
+- ceo: max concurrent 1
+"""
+
+
+def test_parse_brief_reads_run_policy_section() -> None:
+    brief = parse_brief(VALID_BRIEF + _RUN_POLICY_SECTION)
+    assert brief.run_policy_preferences == [
+        "engineer: max turns 8, heartbeat off",
+        "ceo: max concurrent 1",
+    ]
+
+
+def test_parse_brief_run_policy_none_when_section_absent() -> None:
+    # An otherwise-unchanged brief with no run-policy section yields None.
+    assert parse_brief(VALID_BRIEF).run_policy_preferences is None
+
+
+def test_run_policy_preferences_none_by_default() -> None:
+    assert CompanyBrief(**_brief_kwargs()).run_policy_preferences is None
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "ceo: max turns 0",
+        "ceo: max turns abc",
+        "ceo: max concurrent -1",
+        "ceo: heartbeat maybe",
+        "ceo: frobnicate 5",
+        "ceo:",  # no clause
+        "no colon here",
+    ],
+)
+def test_malformed_run_policy_value_rejected(line: str) -> None:
+    with pytest.raises(ValidationError):
+        CompanyBrief(**_brief_kwargs(run_policy_preferences=[line]))
+
+
+def test_same_reference_conflicting_values_rejected() -> None:
+    with pytest.raises(ValidationError):
+        CompanyBrief(
+            **_brief_kwargs(run_policy_preferences=["ceo: max turns 8", "ceo: max turns 5"])
+        )
+
+
+def test_malformed_run_policy_via_parse_brief_raises_brief_error() -> None:
+    bad_section = (
+        "\n\n## 12. Run-policy overrides (optional)\n\n**Your overrides:**\n\n- ceo: max turns 0\n"
+    )
+    with pytest.raises(BriefValidationError):
+        parse_brief(VALID_BRIEF + bad_section)
+
+
+def test_valid_run_policy_preferences_accepted() -> None:
+    brief = CompanyBrief(
+        **_brief_kwargs(run_policy_preferences=["engineer: max turns 8", "ceo: heartbeat off"])
+    )
+    assert brief.run_policy_preferences == ["engineer: max turns 8", "ceo: heartbeat off"]
+
+
 # --- US1 models: agent, skill, output (T017) --------------------------------
 
 

--- a/tests/test_run_policy.py
+++ b/tests/test_run_policy.py
@@ -90,3 +90,156 @@ def test_full_pipeline_emits_run_policy_for_each_role() -> None:
     # CEO (root) → tight concurrency; engineer (non-root worker) → default concurrency.
     assert agents["ceo"]["runPolicy"] == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 1}
     assert agents["engineer"]["runPolicy"] == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 2}
+
+
+# --- brief-driven override layer (feature 014, ADR-034) ----------------------
+
+import pytest  # noqa: E402
+
+from paperclip_blueprints.renderers.run_policy import (  # noqa: E402
+    RunPolicy,
+    RunPolicyOverride,
+    parse_run_policy_line,
+    parse_run_policy_preferences,
+)
+
+
+def _ag(slug: str, *, title: str = "Worker", reports_to: str | None = "ceo") -> AgentDefinition:
+    return AgentDefinition(**_agent_kwargs(slug=slug, title=title, reports_to=reports_to))
+
+
+# tri-state dataclasses
+
+
+def test_run_policy_heartbeat_defaults_none() -> None:
+    p = RunPolicy(max_turns_per_run=30, max_concurrent_runs=2)
+    assert p.heartbeat_enabled is None
+
+
+def test_run_policy_override_all_fields_default_none() -> None:
+    o = RunPolicyOverride()
+    assert (o.max_turns_per_run, o.max_concurrent_runs, o.heartbeat_enabled) == (None, None, None)
+
+
+# line parsing
+
+
+def test_parse_line_turns_and_concurrent() -> None:
+    ref, o = parse_run_policy_line("research-analyst: max turns 8, max concurrent 1")
+    assert ref == "research-analyst"
+    assert o.max_turns_per_run == 8
+    assert o.max_concurrent_runs == 1
+    assert o.heartbeat_enabled is None
+
+
+def test_parse_line_heartbeat_off_and_on() -> None:
+    assert parse_run_policy_line("ceo: heartbeat off")[1].heartbeat_enabled is False
+    assert parse_run_policy_line("ceo: heartbeat on")[1].heartbeat_enabled is True
+
+
+def test_parse_line_aliases_and_case() -> None:
+    _, o = parse_run_policy_line("X: Turns 5, Concurrency 3, Heartbeat Disabled")
+    assert (o.max_turns_per_run, o.max_concurrent_runs, o.heartbeat_enabled) == (5, 3, False)
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "no colon here",
+        "ceo:",  # no clause
+        "ceo: max turns 0",  # non-positive
+        "ceo: max turns -3",
+        "ceo: max turns abc",  # non-integer
+        "ceo: max concurrent 0",
+        "ceo: heartbeat maybe",  # bad token
+        "ceo: frobnicate 5",  # unknown clause
+        "ceo: max turns 5, max turns 8",  # within-line conflict
+    ],
+)
+def test_parse_line_malformed_raises(bad: str) -> None:
+    with pytest.raises(ValueError):
+        parse_run_policy_line(bad)
+
+
+# reference → agent matching
+
+
+def test_parse_prefs_none_returns_empty() -> None:
+    assert parse_run_policy_preferences(None, []) == ({}, [])
+
+
+def test_parse_prefs_matches_by_slug() -> None:
+    agents = [_ag("ceo", title="CEO", reports_to=None), _ag("research-analyst", title="Analyst")]
+    overrides, unmatched = parse_run_policy_preferences(["research-analyst: max turns 8"], agents)
+    assert unmatched == []
+    assert overrides["research-analyst"].max_turns_per_run == 8
+
+
+def test_parse_prefs_is_boundary_safe() -> None:
+    agents = [_ag("senior-analyst", title="Senior Analyst")]
+    overrides, unmatched = parse_run_policy_preferences(["analyst: max turns 5"], agents)
+    assert overrides == {}
+    assert unmatched == ["analyst: max turns 5"]
+
+
+def test_parse_prefs_unmatched_reference_reported() -> None:
+    agents = [_ag("ceo", title="CEO", reports_to=None)]
+    overrides, unmatched = parse_run_policy_preferences(["ghost: heartbeat off"], agents)
+    assert overrides == {}
+    assert unmatched == ["ghost: heartbeat off"]
+
+
+# per-field overlay merge
+
+
+def test_assign_overlay_is_per_field() -> None:
+    ceo = _ag("ceo", title="CEO", reports_to=None)
+    eng = _ag("engineer", title="Engineer")
+    overrides = {"engineer": RunPolicyOverride(max_turns_per_run=8)}
+    policies = assign_run_policies([ceo, eng], overrides)
+    assert policies["engineer"].max_turns_per_run == 8  # overridden
+    assert policies["engineer"].max_concurrent_runs == DEFAULT_MAX_CONCURRENT_RUNS  # base kept
+    # other agent identical to a no-override run
+    assert policies["ceo"] == assign_run_policies([ceo, eng])["ceo"]
+
+
+def test_assign_no_overrides_is_identical_to_today() -> None:
+    ceo = _ag("ceo", title="CEO", reports_to=None)
+    eng = _ag("engineer", title="Engineer")
+    base = assign_run_policies([ceo, eng])
+    assert assign_run_policies([ceo, eng], None) == base
+    assert assign_run_policies([ceo, eng], {}) == base
+
+
+def test_assign_heartbeat_only_from_override() -> None:
+    eng = _ag("engineer", title="Engineer")
+    policies = assign_run_policies([eng], {"engineer": RunPolicyOverride(heartbeat_enabled=False)})
+    assert policies["engineer"].heartbeat_enabled is False
+    # an unmentioned agent stays None
+    assert assign_run_policies([eng], {})["engineer"].heartbeat_enabled is None
+
+
+# render-path carrier
+
+
+def test_render_emits_overrides_and_warns_unmatched() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    config.brief.run_policy_preferences = [
+        "engineer: max turns 8, heartbeat off",
+        "ghost: heartbeat on",
+    ]
+    warnings: list[str] = []
+    out = render_files(config, warn=warnings.append)[".paperclip.yaml"]
+    agents = YAML(typ="safe").load(out)["agents"]
+    assert agents["engineer"]["runPolicy"]["maxTurnsPerRun"] == 8
+    assert agents["engineer"]["runPolicy"]["maxConcurrentRuns"] == 2  # base kept
+    assert agents["engineer"]["runPolicy"]["heartbeatEnabled"] is False
+    # unmentioned agent unchanged, no heartbeat key
+    assert agents["ceo"]["runPolicy"] == {"maxTurnsPerRun": 30, "maxConcurrentRuns": 1}
+    assert any("ghost" in w for w in warnings)
+
+
+def test_render_heartbeat_key_absent_when_unstated() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    out = render_files(config)[".paperclip.yaml"]
+    assert "heartbeatEnabled" not in out

--- a/tests/test_run_policy_backcompat.py
+++ b/tests/test_run_policy_backcompat.py
@@ -1,0 +1,34 @@
+"""Backward-compat gate for feature 014 (release-blocking — do NOT weaken or fold).
+
+A brief with no run-policy values MUST generate byte-identical output to today. The
+golden reference `tests/fixtures/runpolicy_baseline.paperclip.yaml` was frozen from the
+**unmodified** generator BEFORE the feature landed; this test COMPARES against it and must
+never regenerate it. If this test fails, the override layer has leaked into the no-override
+path and every existing operator's bundle is re-priced — treat it as release-blocking.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from paperclip_blueprints.generators.client import LLMClient
+from paperclip_blueprints.renderers.bundle import generate_bundle_full
+from paperclip_blueprints.renderers.render import render_files
+from test_cli import _dispatch_full
+from test_orchestration import _brief
+
+_BASELINE = Path(__file__).parent / "fixtures" / "runpolicy_baseline.paperclip.yaml"
+
+
+def test_no_run_policy_prefs_is_byte_identical_to_baseline() -> None:
+    config = generate_bundle_full(_brief(), LLMClient(_invoke=_dispatch_full))
+    # The fixture brief states no run-policy values.
+    assert config.brief.run_policy_preferences is None
+
+    out = render_files(config)[".paperclip.yaml"]
+    expected = _BASELINE.read_text()
+
+    # (a) byte-identical to the frozen pre-feature output (role rule untouched); and
+    # (b) no heartbeatEnabled key anywhere — the tri-state None renders nothing.
+    assert out == expected
+    assert "heartbeatEnabled" not in out

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -25,6 +25,26 @@ def test_valid_full_bundle_passes() -> None:
     validate_bundle(config, files)  # must not raise
 
 
+def test_s16_run_policy_heartbeat_must_be_boolean() -> None:
+    # S16 (feature 014): runPolicy.heartbeatEnabled, when present, must be a boolean.
+    from paperclip_blueprints.validators.schema_shape import _check_run_policy_fields
+
+    ok = (
+        "agents:\n  ceo:\n    runPolicy:\n      maxTurnsPerRun: 30\n"
+        "      maxConcurrentRuns: 1\n      heartbeatEnabled: false\n"
+    )
+    assert _check_run_policy_fields(ok) == []
+
+    bad = (
+        "agents:\n  ceo:\n    runPolicy:\n      maxTurnsPerRun: 30\n"
+        "      maxConcurrentRuns: 1\n      heartbeatEnabled: maybe\n"
+    )
+    problems = _check_run_policy_fields(bad)
+    assert len(problems) == 1
+    assert "S16" in problems[0]
+    assert "ceo" in problems[0]
+
+
 def test_valid_single_bundle_passes() -> None:
     from test_templates import _config
 


### PR DESCRIPTION
Lets the brief state per-agent run-policy values — max turns per run, max concurrent runs, and a heartbeat on/off toggle — carried into `.paperclip.yaml` `runPolicy` for the deployer to apply.

## Design
- **Layers over ADR-027**: brief values overlay the role-derived base per agent and field; the role rule is untouched. Heartbeat is a new brief-only tri-state, emitted only when stated.
- **Pure carrier**: no defaults/heuristics/inference — transports operator-stated values only. Deterministic, no LLM, no I/O. Reuses the adapter boundary-safe reference matcher.
- **Validation**: malformed values rejected at brief validation; unmatched references warned at render; cross-reference collisions resolve last-in-order (see ADR-034 deviation note).
- **Backward compatible**: a brief with no run-policy values renders byte-identical to today — enforced by a release-blocking frozen-baseline gate.

## Artifacts
- Spec/plan/tasks: `specs/014-run-policy-override/`
- Decision: `docs/adr/034-brief-run-policy-override.md`
- Tests: 395 passed / 2 skipped; ruff + ruff-format + pyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)