### PR TITLE
fix(validator): prevent generated agents binding to built-in Paperclip agents

### DIFF
--- a/src/paperclip_blueprints/paperclip_slug.py
+++ b/src/paperclip_blueprints/paperclip_slug.py
@@ -32,6 +32,22 @@ def slugify_project_name(name: str) -> str:
     return _TRIM_DASH_RE.sub("", dashed)
 
 
+def slugify_agent_name(name: str) -> str:
+    """Return the Paperclip agent URL key for a display name.
+
+    Mirrors ``normalizeAgentUrlKey`` in ``packages/shared/src/agent-url-key.ts``
+    (read at ``v2026.720.0``), which Paperclip uses to derive an agent's key from its
+    display ``name`` — the ``agents`` table has no ``slug`` column. The algorithm is
+    character-for-character the same as :func:`slugify_project_name`
+    (trim → lowercase → collapse ``[^a-z0-9]+`` to ``-`` → strip edge ``-``); it is
+    exposed under its own name so agent-side callers cite the agent source, and so the
+    two stay independently updatable if Paperclip ever diverges them.
+
+    Returns ``""`` where Paperclip returns ``null`` (empty or all-non-ASCII name).
+    """
+    return slugify_project_name(name)
+
+
 def dedupe_slug(base: str, used: set[str]) -> str:
     """Return a unique slug for ``base``, mirroring Paperclip's ``uniqueSlug``.
 

--- a/src/paperclip_blueprints/patterns/builtins.py
+++ b/src/paperclip_blueprints/patterns/builtins.py
@@ -52,6 +52,54 @@ BUILTIN_SKILLS: frozenset[str] = frozenset(
 )
 
 
+# --- Built-in Paperclip AGENTS (reserved name space) -------------------------
+#
+# SOURCE: ``server/src/services/built-in-agents.ts`` → the ``DEFINITIONS`` array
+#         (``const DEFINITIONS = validateBuiltInAgentDefinitions([...])``, line 302)
+#         in ``paperclipai/paperclip``.
+# READ AT: Paperclip **v2026.720.0** (tag), on 2026-07-21.
+#
+# WHY THIS IS RESERVED, and why it is a hardcoded platform fact:
+#   Built-in agents are ordinary rows in the ``agents`` table carrying immutable
+#   ``metadata.paperclipBuiltInAgent``. That table has **no ``slug`` column and no
+#   unique constraint on ``(company_id, name)``** — Paperclip derives an agent's key at
+#   runtime with ``normalizeAgentUrlKey(name)``, i.e. from the DISPLAY NAME. The two
+#   ``bundle`` definitions (``reflection-coach``, ``summarizer``) are auto-provisioned
+#   into EVERY company by ``companies.create`` → ``autoProvisionBundledAgents``, and
+#   re-reconciled on every server boot. So a generated agent whose name normalizes onto
+#   one of these keys lands in an occupied namespace: on a ``new_company`` import the
+#   collision check never runs at all (it is gated on ``existing_company``), yielding two
+#   same-named agents and NO error; on ``existing_company`` + ``replace`` it instead hits
+#   ``built_in_agent_marker_readonly``. Built-ins are also undeletable, so an import can
+#   never clean up after itself. The failure is therefore silent or unrecoverable, never
+#   a clean rejection — which is why this is enforced at generation time.
+#
+#   NOTE: the ``enableBuiltInAgents`` experimental setting gates the built-in agent
+#   ROUTES only, not ``autoProvisionBundledAgents``. Turning the feature off leaves the
+#   rows — and this collision surface — in place. Do not treat it as a mitigation.
+#
+# MAINTENANCE — this list WILL go stale; Paperclip's registry is designed to grow, and
+# its keys are permanent once released ("Do not rename keys after release",
+# ``docs/built-in-agents.md``). On a new Paperclip release, re-read the ``DEFINITIONS``
+# array above and add any new entry's *derived slug* here, then bump READ AT.
+#
+# The reserved values below are the ``slugify_agent_name(displayName)`` of each
+# definition — the actual collision surface. Registry ``key`` is recorded alongside for
+# traceability, and deliberately NOT reserved where it differs from the derived slug
+# (``briefs``/``learning``), since reserving those would block legitimate agent names
+# like "Learning Designer" for a collision that cannot occur.
+#
+#   registry key      | displayName        | derived slug (reserved)
+#   ------------------|--------------------|------------------------
+#   briefs            | "Briefs Agent"     | briefs-agent
+#   learning          | "Learning Agent"   | learning-agent
+#   reflection-coach  | "Reflection Coach" | reflection-coach   (auto-provisioned)
+#   summarizer        | "Summarizer"       | summarizer         (auto-provisioned)
+BUILTIN_AGENT_SLUGS: frozenset[str] = frozenset(
+    {"briefs-agent", "learning-agent", "reflection-coach", "summarizer"}
+)
+
+
 def builtin_skills_for(*, is_ceo: bool, is_lead: bool) -> list[str]:
     """Return the built-in skill slugs a role should declare, in canonical order.
 

--- a/src/paperclip_blueprints/prompts/org_planner.md
+++ b/src/paperclip_blueprints/prompts/org_planner.md
@@ -12,6 +12,14 @@ collides with the human principal: do not use **"Founder"**, **"Co-founder"**, o
 (e.g. "Managing Editor", "Studio Head") — kept clearly distinct from the human
 Founder/Board. Every agent name is a working role INSIDE the company.
 
+Separately, Paperclip ships **built-in agents** that already exist in every company
+and own their names. Never name an agent, and never give an agent a title, that
+matches any of: **"Summarizer"**, **"Reflection Coach"**, **"Briefs Agent"**,
+**"Learning Agent"** (in any casing or punctuation). A qualified name is fine when it
+does not reduce to one of those — "Content Summarizer" and "Learning Designer" are
+allowed; a bare "Summarizer" is not. If a role genuinely is summarization, name it for
+the work it owns (e.g. "Digest Editor").
+
 ## Ownership chains (how to shape the tree)
 
 Design the org so every capability the company needs has exactly ONE accountable

--- a/src/paperclip_blueprints/validators/integrity.py
+++ b/src/paperclip_blueprints/validators/integrity.py
@@ -14,8 +14,8 @@ from ruamel.yaml import YAML
 
 from ..models.org_plan import SPAN_OF_CONTROL
 from ..models.output import CompanyConfig
-from ..paperclip_slug import slugify_project_name
-from ..patterns.builtins import BUILTIN_SKILLS
+from ..paperclip_slug import slugify_agent_name, slugify_project_name
+from ..patterns.builtins import BUILTIN_AGENT_SLUGS, BUILTIN_SKILLS
 
 # Reserved human-principal role-words (ADR-016): an agent name/title must not collide
 # with the human founder/board, who sit above the company as its approver and are
@@ -148,6 +148,20 @@ def check_integrity(config: CompanyConfig, files: dict[str, str]) -> list[str]:
                     f"I13: agent {a.slug!r} {field} {value!r} collides with the human "
                     f"founder/board role; name agents for working roles (e.g. CEO), not "
                     f"Founder/Board"
+                )
+
+    # I15: no agent name/title collides with a built-in Paperclip agent. Paperclip
+    # derives an agent's key from its DISPLAY NAME, so the check normalizes name and
+    # title the same way (`normalizeAgentUrlKey`) rather than matching literal tokens.
+    # See `patterns.builtins.BUILTIN_AGENT_SLUGS` for the source and the version it was
+    # read at — the reserved set is a platform fact that needs re-reading each release.
+    for a in agents:
+        for field, value in (("name", a.name), ("title", a.title)):
+            if slugify_agent_name(value) in BUILTIN_AGENT_SLUGS:
+                v.append(
+                    f"I15: agent {a.slug!r} {field} {value!r} collides with the built-in "
+                    f"Paperclip agent {slugify_agent_name(value)!r}, which is "
+                    f"auto-provisioned into every company; rename the agent"
                 )
 
     # I14: goal-hierarchy closure (ADR-025). Structural invariants (one root, resolvable/

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -271,6 +271,61 @@ def test_i13_ignores_substrings(value: str) -> None:
     assert not any(x.startswith("I13") for x in check_integrity(config, files))
 
 
+# --- platform: built-in agent name collision I15 ----------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "Summarizer",
+        "summarizer",
+        "Reflection Coach",
+        "reflection-coach",
+        "Briefs Agent",
+        "Learning Agent",
+        "  Summarizer  ",
+        "REFLECTION COACH",
+        "Reflection  Coach",
+    ],
+)
+def test_i15_rejects_builtin_agent_name(value: str) -> None:
+    # Paperclip derives an agent's key from its display name, so any name that
+    # normalizes onto a built-in's key collides in the shared namespace.
+    config, files = _valid()
+    config.agents[0].name = value
+    violations = check_integrity(config, files)
+    assert any(x.startswith("I15") for x in violations)
+    assert config.agents[0].slug in " ".join(v for v in violations if v.startswith("I15"))
+
+
+def test_i15_rejects_builtin_in_title() -> None:
+    config, files = _valid()
+    config.agents[0].title = "Summarizer"
+    assert any(x.startswith("I15") for x in check_integrity(config, files))
+
+
+@pytest.mark.parametrize(
+    "value",
+    # Near-misses that do NOT normalize onto a reserved key, and the two registry
+    # *keys* whose derived slugs differ ("briefs"/"learning" vs "briefs-agent"/
+    # "learning-agent") — reserving those would block legitimate roles.
+    [
+        "Content Summarizer",
+        "Summary Writer",
+        "Coach",
+        "Briefs",
+        "Learning",
+        "Learning Designer",
+        "Reflection Lead",
+    ],
+)
+def test_i15_allows_non_colliding_names(value: str) -> None:
+    config, files = _valid()
+    config.agents[0].name = value
+    config.agents[0].title = value
+    assert not any(x.startswith("I15") for x in check_integrity(config, files))
+
+
 # --- governance: board-authority presence S11 (ADR-016) ---------------------
 
 


### PR DESCRIPTION
## What this prevents

Paperclip auto-provisions built-in agents into every company. They are ordinary rows in the `agents` table — there is no `slug` column and no unique constraint on `(company_id, name)` — and an agent's key is derived at runtime from its **display name** via `normalizeAgentUrlKey`.

So a generated agent named "Summarizer" or "Reflection Coach" lands in an already-occupied namespace, and the failure is silent or unrecoverable rather than a clean rejection:

- **New-company import** — the collision check never runs (it is gated on the existing-company path). Two same-named agents, no error, and the generated agent can bind to the built-in.
- **Existing-company replace** — hits a readonly built-in marker and fails the agent update.
- **Either way** — built-in agents cannot be deleted, so an import can never clean up after the collision.

## What changed

- **New validator `I15`** — rejects any agent whose `name` or `title` normalizes onto a built-in key. The match mirrors `normalizeAgentUrlKey` (trim → lowercase → collapse non-alphanumerics to `-`) rather than matching literal tokens, so casing and spacing variants are caught.
- **`BUILTIN_AGENT_SLUGS`** — the reserved set, carrying its source and the version it was read at.
- **`slugify_agent_name`** — mirrors `normalizeAgentUrlKey`, alongside the existing project-key derivation.
- **`org_planner` prompt guard** — generation avoids these names instead of aborting the run on them, matching the existing founder/board guard.

## Design notes

**`I15` is kept separate from `I13` (founder/board).** `I13` is a stable governance rule; the built-in set is a version-pinned platform fact that must be re-read each release. Merging them would put a version caveat on a rule that does not need one.

**Four derived slugs are reserved, not the registry keys** — `summarizer`, `reflection-coach`, `briefs-agent`, `learning-agent`. For `briefs` and `learning` the registry key differs from the derived slug, and reserving the bare keys would block legitimate names like "Learning Designer" for a collision that cannot occur, since Paperclip derives from the display name.

**The denylist is sourced and dated on purpose.** The built-in registry is designed to grow and its keys are permanent once released, so an unsourced list goes stale silently. A new built-in should be a one-line update, not a rediscovery after an agent has already bound to one.

Source: `server/src/services/built-in-agents.ts` (the `DEFINITIONS` array) and `packages/shared/src/agent-url-key.ts`, both read at Paperclip **v2026.720.0**.

## Testing

17 new tests covering collision variants (casing, spacing, padding), title as well as name, and near-misses that must still be allowed ("Content Summarizer", "Learning Designer", bare "Briefs"/"Learning").

Full suite: 412 passed, 2 skipped (both API-gated). `ruff check` + `ruff format` clean, pyright 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)