### PR TITLE
Remediate 27 non-falsifiable guard emission sites (ADR-046)

### DIFF
--- a/tests/test_goal_hierarchy.py
+++ b/tests/test_goal_hierarchy.py
@@ -324,3 +324,38 @@ def test_bundle_validator_flags_goal_owner_not_in_org() -> None:
     config.goal_hierarchy.goals[1].owner = "ghost"
     files = render_files(config)
     assert any(v.startswith("I14") and "ghost" in v for v in check_integrity(config, files))
+
+
+# --- ADR-046 Class B: I14's other two sites, unreached by any existing test --------
+#
+# `GoalHierarchy` itself rejects two roots / a dangling parent at construction (see the model
+# invariant tests above), so the validator's own I14 root/parent checks can only be reached by
+# mutating an already-constructed hierarchy — exactly as the owner-closure test above does.
+
+
+def test_bundle_validator_flags_goal_hierarchy_with_two_roots() -> None:
+    from paperclip_blueprints.renderers.render import render_files
+    from paperclip_blueprints.validators.integrity import check_integrity
+
+    config = _full_config_with_hierarchy(
+        [_goal("north-star", None, "ceo", "company"), _goal("arch", "north-star", "cto", "agent")]
+    )
+    assert config.goal_hierarchy is not None
+    config.goal_hierarchy.goals.append(_goal("other-root", None, "cto", "company"))
+    files = render_files(config)
+    violations = [v for v in check_integrity(config, files) if v.startswith("I14")]
+    assert any("exactly one root" in v and "other-root" in v for v in violations)
+
+
+def test_bundle_validator_flags_goal_with_unknown_parent() -> None:
+    from paperclip_blueprints.renderers.render import render_files
+    from paperclip_blueprints.validators.integrity import check_integrity
+
+    config = _full_config_with_hierarchy(
+        [_goal("north-star", None, "ceo", "company"), _goal("arch", "north-star", "cto", "agent")]
+    )
+    assert config.goal_hierarchy is not None
+    config.goal_hierarchy.goals[1].parent = "ghost-parent"
+    files = render_files(config)
+    violations = [v for v in check_integrity(config, files) if v.startswith("I14")]
+    assert any("unknown parent" in v and "ghost-parent" in v for v in violations)

--- a/tests/test_routines.py
+++ b/tests/test_routines.py
@@ -606,6 +606,29 @@ def test_s15_flags_an_orphan_routine_block() -> None:
     assert any(x.startswith("S15") and "ghost" in x for x in check_schema_shape(config, files))
 
 
+def test_s15_flags_a_recurring_task_with_no_routines_block() -> None:
+    """ADR-046 Class B — the sibling site: an orphan routine block (above) reads the message
+    for `routines.{orphan}` text; the other direction, a recurring task whose block was
+    stripped from `.paperclip.yaml`, is a separate line and was unreached by any test.
+    """
+    import re as _re
+
+    config = CompanyConfig(
+        **_full_config_kwargs(
+            tasks=[
+                _task("ship", "Ship"),
+                _task("signal-scan", "Signal scan", recurrence=Cadence.coerce("weekly")),
+            ]
+        )
+    )
+    files = render_files(config)
+    assert "routines:" in files[".paperclip.yaml"], "fixture must actually emit a routine"
+    files[".paperclip.yaml"] = _re.sub(r"\nroutines:\n(?:  .*\n)*", "\n", files[".paperclip.yaml"])
+    assert "routines:" not in files[".paperclip.yaml"]
+    violations = [x for x in check_schema_shape(config, files) if x.startswith("S15")]
+    assert any("signal-scan" in x and "has no .paperclip.yaml routines" in x for x in violations)
+
+
 # --- producer/consumer ordering (feature 015, US3) ---------------------------
 #
 # FR-008: fires when one task names another, they share a day pattern, and the referencing task

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -10,10 +10,12 @@ import pytest
 from paperclip_blueprints.config import AGENT_TOP_TIER_MODEL
 from paperclip_blueprints.models.agent import AgentDefinition
 from paperclip_blueprints.models.output import CompanyConfig
+from paperclip_blueprints.models.skill import SkillDefinition
 from paperclip_blueprints.renderers.render import render_files
 from paperclip_blueprints.validators import BundleValidationError, validate_bundle
 from paperclip_blueprints.validators.integrity import check_integrity
-from test_models import _agent_kwargs, _full_config_kwargs
+from paperclip_blueprints.validators.schema_shape import check_schema_shape
+from test_models import _agent_kwargs, _full_config_kwargs, _skill_kwargs
 
 
 def _valid() -> tuple[CompanyConfig, dict[str, str]]:
@@ -84,8 +86,12 @@ def test_s7_anti_drift_must_cover_every_constraint() -> None:
     # Only one of the four constraints/negations is covered; the rest are dropped.
     assert config.operations is not None
     config.operations.anti_drift_checks = ["We are NOT a free-to-play studio."]
-    with pytest.raises(BundleValidationError, match="S7"):
-        validate_bundle(config, files)
+    violations = check_schema_shape(config, files)
+    # Message-level per ADR-046 (Class B): a bare "S7" prefix match would also pass if this
+    # code reported the wrong dropped item, or if only the unrelated `test_s7_missing_
+    # operations_heading` site fired — name the specific constraint that went uncovered.
+    drift_violations = [x for x in violations if "anti-drift checks do not cover" in x]
+    assert any(x.startswith("S7") and "One title at a time." in x for x in drift_violations)
 
 
 def test_s7_accepts_paraphrased_anti_drift() -> None:
@@ -108,6 +114,99 @@ def test_s9_body_only_file_must_not_carry_schema() -> None:
     files[key] = "---\nschema: agentcompanies/v1\n---\n" + files[key]
     with pytest.raises(BundleValidationError, match="S9"):
         validate_bundle(config, files)
+
+
+# --- ADR-046 Class A: guards with no test naming them at all -----------------
+
+
+def test_s3_agents_md_missing_frontmatter_key() -> None:
+    config, files = _valid()
+    key = next(k for k in files if k.endswith("AGENTS.md"))
+    files[key] = files[key].replace("reportsTo:", "notReportsTo:", 1)
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S3") and key in x and "reportsTo:" in x for x in violations)
+
+
+def test_s3_task_md_missing_frontmatter_key() -> None:
+    config, files = _valid()
+    key = next(k for k in files if k.endswith("TASK.md"))
+    files[key] = files[key].replace("assignee:", "notAssignee:", 1)
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S3") and key in x and "assignee:" in x for x in violations)
+
+
+def test_s3_project_md_missing_owner_key() -> None:
+    config, files = _valid()
+    key = next(k for k in files if k.endswith("PROJECT.md"))
+    # "ownerx:" (not "notowner:") so the substring "owner:" is genuinely gone, not just
+    # embedded in a longer key — a naive rename can leave the guard's `in` check satisfied
+    # by accident.
+    files[key] = files[key].replace("owner:", "ownerx:", 1)
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S3") and key in x and "owner:" in x for x in violations)
+
+
+def test_s4_agents_md_missing_heading() -> None:
+    config, files = _valid()
+    key = next(k for k in files if k.endswith("AGENTS.md"))
+    files[key] = files[key].replace("## Mandate", "## Not Mandate", 1)
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S4") and key in x and "Mandate" in x for x in violations)
+
+
+def test_s4_soul_md_missing_believe_heading() -> None:
+    config, files = _valid()
+    key = next(k for k in files if k.endswith("SOUL.md"))
+    files[key] = files[key].replace("## What I believe in", "## Beliefs", 1)
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S4") and key in x and "What I believe in" in x for x in violations)
+
+
+def test_s5_too_few_we_are_not_entries() -> None:
+    config, files = _valid()
+    config.company.we_are_not = ["We are NOT a free-to-play studio."]
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S5") and "we are not" in x for x in violations)
+
+
+def test_s5_too_few_constraints() -> None:
+    config, files = _valid()
+    config.company.constraints = ["One title at a time."]
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S5") and "constraints" in x for x in violations)
+
+
+def test_s8_starter_block_count_mismatch() -> None:
+    config, files = _valid()
+    files["PROJECT-INVENTORY.md"] += "\n### Extra Starter\n"
+    violations = check_schema_shape(config, files)
+    assert any(x.startswith("S8") and "starter blocks" in x for x in violations)
+
+
+def test_s8_completed_table_not_empty_at_generation() -> None:
+    config, files = _valid()
+    header = "| Deliverable | Owner | Location | Completed |\n| --- | --- | --- | --- |\n"
+    assert header in files["PROJECT-INVENTORY.md"]
+    files["PROJECT-INVENTORY.md"] = files["PROJECT-INVENTORY.md"].replace(
+        header, header + "| Ship v1 | cto | releases/v1 | 2026-01-01 |\n", 1
+    )
+    violations = check_schema_shape(config, files)
+    assert any(
+        x.startswith("S8") and "Completed deliverables" in x and "must be empty" in x
+        for x in violations
+    )
+
+
+# --- ADR-046 Class B: a test names the guard, but not every site it emits from ----
+
+
+def test_s7_missing_operations_heading() -> None:
+    config, files = _valid()
+    files["OPERATIONS.md"] = files["OPERATIONS.md"].replace("## Phase model", "## Phases", 1)
+    violations = check_schema_shape(config, files)
+    assert any(
+        x.startswith("S7") and "missing section" in x and "Phase model" in x for x in violations
+    )
 
 
 # --- integrity rejections ---------------------------------------------------
@@ -134,11 +233,146 @@ def test_i5_dangling_skill_reference() -> None:
         validate_bundle(config, files)
 
 
+# I5 emits three distinct violations from three separate sites (duplicate slug, agent → no
+# SKILL.md, skill → no agent). `test_i5_dangling_skill_reference` above trips the latter two
+# simultaneously and matches only the "I5" prefix, so per ADR-046 (Class B) each site below is
+# isolated and asserted on its specific message, and the duplicate-slug site (unreached by any
+# test) gets one from scratch.
+
+
+def test_i5_duplicate_skill_slug() -> None:
+    config, files = _valid()
+    dup_slug = config.skills[0].slug
+    config.skills[1].slug = dup_slug  # both skills now share one slug
+    violations = check_integrity(config, files)
+    assert any(
+        x.startswith("I5") and "duplicate skill slug" in x and dup_slug in x for x in violations
+    )
+
+
+def test_i5_agent_references_skill_with_no_skill_md() -> None:
+    config, files = _valid()
+    # keep the agent's real skill so it stays referenced; only add the dangling one, so the
+    # "skill referenced by no agent" site cannot also fire and mask this one.
+    config.agents[0].skills = [*config.agents[0].skills, "ghost-skill"]
+    violations = check_integrity(config, files)
+    assert any(
+        x.startswith("I5") and "references skill" in x and "ghost-skill" in x for x in violations
+    )
+
+
+def test_i5_skill_referenced_by_no_agent() -> None:
+    config, files = _valid()
+    config.skills.append(SkillDefinition(**_skill_kwargs(slug="orphan-skill", name="orphan-skill")))
+    violations = check_integrity(config, files)
+    assert any(
+        x.startswith("I5") and "is referenced by no agent" in x and "orphan-skill" in x
+        for x in violations
+    )
+
+
 def test_i6_dangling_task_project() -> None:
     config, files = _valid()
     config.tasks[0].project = "ghost-project"
     with pytest.raises(BundleValidationError, match="I6"):
         validate_bundle(config, files)
+
+
+# --- ADR-046 Class A: guards with no test naming them at all -----------------
+
+
+def test_i3_cycle_in_reporting_graph() -> None:
+    config, files = _valid()
+    # ceo (root) now reports to cto, who already reports to ceo: a 2-node cycle.
+    config.agents[0].reports_to = config.agents[1].slug
+    violations = check_integrity(config, files)
+    assert any(x.startswith("I3") and "cycle" in x for x in violations)
+
+
+def test_i7_project_owned_by_unknown_agent() -> None:
+    config, files = _valid()
+    config.projects[0].owner = "ghost"
+    violations = check_integrity(config, files)
+    assert any(x.startswith("I7") and "ghost" in x for x in violations)
+
+
+def test_i8_handoff_names_unknown_agent() -> None:
+    config, files = _valid()
+    config.agents[0].hands_to = ["ghost — reviews releases"]
+    violations = check_integrity(config, files)
+    assert any(x.startswith("I8") and "ghost" in x for x in violations)
+
+
+def test_i9_missing_paperclip_yaml() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    problems = _check_paperclip_yaml("", {"ceo"}, {"launch-v1"})
+    assert problems == ["I9: .paperclip.yaml is missing"]
+
+
+def test_i9_invalid_yaml() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    problems = _check_paperclip_yaml("agents: [unterminated", {"ceo"}, set())
+    assert len(problems) == 1
+    assert problems[0].startswith("I9: .paperclip.yaml is not valid YAML")
+
+
+def test_i9_agents_map_mismatch() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    yaml_text = "agents:\n  ghost: {}\nprojects: {}\nsidebar:\n  agents: [ceo]\n  projects: []\n"
+    problems = _check_paperclip_yaml(yaml_text, {"ceo"}, set())
+    assert any(p.startswith("I9") and "agents map" in p for p in problems)
+
+
+def test_i9_projects_map_mismatch() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    yaml_text = (
+        "agents:\n  ceo: {}\nprojects:\n  ghost: {}\n"
+        "sidebar:\n  agents: [ceo]\n  projects: [launch-v1]\n"
+    )
+    problems = _check_paperclip_yaml(yaml_text, {"ceo"}, {"launch-v1"})
+    assert any(p.startswith("I9") and "projects map" in p for p in problems)
+
+
+def test_i9_sidebar_agents_mismatch() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    yaml_text = "agents:\n  ceo: {}\nprojects: {}\nsidebar:\n  agents: [ghost]\n  projects: []\n"
+    problems = _check_paperclip_yaml(yaml_text, {"ceo"}, set())
+    assert any(p.startswith("I9") and "sidebar.agents" in p for p in problems)
+
+
+def test_i9_sidebar_projects_mismatch() -> None:
+    from paperclip_blueprints.validators.integrity import _check_paperclip_yaml
+
+    yaml_text = (
+        "agents:\n  ceo: {}\nprojects:\n  launch-v1: {}\n"
+        "sidebar:\n  agents: [ceo]\n  projects: [ghost]\n"
+    )
+    problems = _check_paperclip_yaml(yaml_text, {"ceo"}, {"launch-v1"})
+    assert any(p.startswith("I9") and "sidebar.projects" in p for p in problems)
+
+
+def test_i10_missing_files() -> None:
+    config, files = _valid()
+    del files["COMPANY.md"]
+    violations = check_integrity(config, files)
+    assert any(
+        x.startswith("I10") and "missing files" in x and "COMPANY.md" in x for x in violations
+    )
+
+
+def test_i10_unexpected_files() -> None:
+    config, files = _valid()
+    files["extra/ghost.md"] = "junk"
+    violations = check_integrity(config, files)
+    assert any(
+        x.startswith("I10") and "unexpected files" in x and "extra/ghost.md" in x
+        for x in violations
+    )
 
 
 def test_i4_span_of_control() -> None:


### PR DESCRIPTION
## Summary

- Per BLUA-9/BLUA-10 routing and the classification in `docs/working/blua-8-falsifiability-report-49b472c.md`, adds one test per non-falsifiable emission site — no amendment to the classification.
- **Class A** (`I3`, `I7`, `I8`, `I9`, `I10`, `S3`, `S4`, `S5`, `S8`): written from scratch, each test constructing the specific violating state and asserting the guard reports it. `I9` and `I10` (both import-blocking, zero prior protection) done first per ADR-046 §3.
- **Class B** (`I5`, `I14`, `S7`, `S15`): rewritten from `pytest.raises(BundleValidationError, match="<ID>")` prefix matches to per-site message assertions, plus a new test for each site the existing per-ID test didn't reach.
- 27 new tests (849 total, up from the audited 822) — one per emission site named in the report.

## Test plan

- [x] `uv run pytest -q` — 849 passed, 2 skipped
- [x] `uv run ruff check` / `uv run ruff format --check` on touched files — clean
- [x] Spot-verified 3 of the 27 sites (`I3` cycle, `I9` missing-`.paperclip.yaml`, `S5` constraints) by locally mutating the guard and confirming the matching new test goes red, then restoring the source — not a substitute for QA Lead's full mutation re-run.

Per ADR-046 decision 2, none of these 27 sites may be cited as enforcement evidence until QA Lead re-runs the mutation harness per site and reclassifies each `FALSIFIABLE-VERIFIED`. Handoff comment posted on BLUA-10 referencing this PR, BLUA-9, and ADR-046.

🤖 Generated with [Claude Code](https://claude.com/claude-code)