### PR TITLE
Exclusive per-tree lock for mutation-testing sweeps (ADR-046 §4)

### DIFF
--- a/scripts/mutation_tree_lock.md
+++ b/scripts/mutation_tree_lock.md
@@ -1,0 +1,154 @@
+# Stale-lock procedure — mutation-testing sweeps
+
+Companion to `scripts/mutation_tree_lock.py`. Board ruling BLUA-11 (`local-board`, 2026-09-05,
+adopt as amended), recorded in ADR-046 §4 and Consequences.
+
+This exists because the step it replaces was improvised. F-3 entered a run to find a stranded
+mutation in the working tree with no surviving copy; the leftover was cleared and the run
+continued. Nothing recorded what the tree was verified against, and nothing said whether the
+mutator that stranded it was still running. That is the gap this document closes.
+
+---
+
+## The rule in one line
+
+**A stale lock is a tree-integrity incident, not a file to delete.**
+
+A cooperative lock stops a second sweep from *starting*. It does not stop an orphaned mutator
+that is already past its own check — F-2's second harness outlived the run that started it.
+So a lock with no live holder means two things may be true at once: the tree may carry a
+stranded mutation, and something may still be writing to it.
+
+## What the harness does on its own
+
+| Situation | Harness | Exit |
+|---|---|---|
+| No lock | acquires, sweeps, releases | 0 |
+| Lock held by a **live** holder | refuses; `LockHeld` | 2 |
+| Lock with **no live** holder (dead, unknown host, unreadable) | refuses; `StaleLockIncident` | 3 |
+
+Neither refusal deletes anything. Clearing is a separate, deliberate act — this procedure.
+
+Liveness is pid **and** process start time, both recorded in the lock at acquisition. Pids are
+recycled; a pid-only check reports live as soon as the number is reissued, and the lock would
+then never be clearable except by hand — reintroducing the very step that produced F-3.
+
+---
+
+## Procedure
+
+Run every step. Do not skip step 3 because the tree "looks clean" — a neutralised guard is a
+one-line edit that changes no line numbers, which is exactly what it was designed to be.
+
+### 1. Read the lock
+
+```bash
+uv run python scripts/mutation_tree_lock.py inspect --tree "$TREE"
+```
+
+Record `holder.run_id`, `holder.pid`, `holder.hostname`, `holder.acquired_at`, and `liveness`.
+If `state` is `live`, **stop** — this is not a stale lock. Wait for that sweep, or find its
+operator. Clearing is not an eviction route and `clear_stale` refuses a live holder.
+
+### 2. Establish that no mutator is still running
+
+```bash
+ps -p "<holder.pid>"                     # expect: no such process
+pgrep -fl 'harness.py|mutation_tree_lock' # expect: nothing but your own shell
+```
+
+If anything matches, you have F-2's situation — a second harness on a shared tree. Do not
+clear. Escalate to Head of Engineering, identify the process's run, and stop it before going
+further. Any sweep that overlapped it is discarded, not repaired: its verdicts are
+cross-attributed and its own output cannot reveal that.
+
+If `liveness` was `unknown` rather than `dead` — a lock written on another host, or one whose
+holder start time was never captured — you cannot establish this from `ps` alone. Say so in the
+`--note` at step 5 rather than recording a check you did not perform.
+
+### 3. Verify the tree against version control
+
+This is the step the ruling turns on: the tree is verified **before the next sweep starts**,
+not after it produces results.
+
+```bash
+git status --porcelain                   # untracked/modified files
+git diff --stat                          # any content drift
+git stash list                           # a mutation parked rather than restored
+```
+
+Then, specifically for the sweep's own mutation marker:
+
+```bash
+grep -rn 'MUTATED-' --include='*.py' src/ scripts/ || echo "no mutation markers"
+```
+
+(`--include='*.py'` keeps this file, which quotes the marker, out of its own results — a
+procedure that always reports a hit teaches the reader to ignore the hit.)
+
+Decide and record one of:
+
+- **Tree clean** — `git status` empty and no markers. Note the commit SHA; that is your
+  `--verified-against`.
+- **Stranded mutation found** — restore the affected file from the audit's baseline copy
+  (`~/.paperclip/qa-audits/<audit>/baseline/`), not from `git checkout`. Restoring from version
+  control is a protocol deviation: it is recorded as cleanup, and **no guard is credited** on
+  any sweep that relied on it. Re-run the suite and confirm green before continuing.
+- **Unexpected uncommitted work** — not the sweep's doing. Leave it, and name it in the note;
+  the next sweep's baseline must be taken from a tree you can describe.
+
+### 4. Read the journal of the interrupted sweep
+
+`records.jsonl` in the audit directory. Every mutation is journalled *before* it is applied, so
+the last `about-to-mutate` record with no matching `complete` record names the site the crash
+left behind. Cross-check it against what step 3 found. A disagreement between the two is itself
+a finding — report it; do not reconcile it silently.
+
+### 5. Clear, with the verification on the record
+
+```bash
+uv run python scripts/mutation_tree_lock.py clear \
+  --tree "$TREE" \
+  --verified-against "<commit SHA from step 3>" \
+  --cleared-by "<named clearer>" \
+  --note "<what step 2/3/4 found>"
+```
+
+Both `--verified-against` and `--cleared-by` are required; the call is refused if either is
+blank. A gate with no named clearer is not reviewed, and a clear with no verification reference
+is the improvised deletion this procedure replaces. The incident is appended to
+`incidents.jsonl` beside the lock **before** the lock file is unlinked, so a crash between the
+two leaves the record rather than silence.
+
+### 6. Only then, start the sweep
+
+```bash
+uv run python ~/.paperclip/qa-audits/<audit>/harness.py snapshot   # fresh baseline copies
+uv run python ~/.paperclip/qa-audits/<audit>/harness.py sweep --release "<SHA>"
+```
+
+Take the baseline copies **after** step 3, never before. F-2's second harness snapshotted its
+"pristine" copy while a guard was already neutralised, then verified each restore by comparing
+that copy against itself — an identical-sides comparison inside the audit instrument, and every
+contaminated site still reported `restore_green=True`.
+
+---
+
+## Reporting
+
+A cleared incident is not a closed finding. Include in the sweep's report:
+
+- the incident record from `incidents.jsonl`, verbatim;
+- whether a stranded mutation was found, and how it was restored;
+- if version control was used to restore, the explicit statement that no guard is credited on
+  that basis.
+
+## Scope limits — what this does not cover
+
+- **The lock does not protect the lock.** A sweep against `mutation_tree_lock.py` itself cannot
+  be guarded by it. The BLUA-14 sweep of this module ran single-process and sequential, and
+  asserted the tree byte-identical to the copy before and after each mutation instead.
+- **Cooperative only.** Any process not going through `TreeLock` is unaffected. The lock makes
+  a concurrent sweep *detectable and refused at start*; it does not make one impossible.
+- **One host.** A lock from another hostname classifies as `unknown` and refuses. Cross-host
+  concurrent sweeps on a shared filesystem are out of scope and would need a different design.

--- a/scripts/mutation_tree_lock.py
+++ b/scripts/mutation_tree_lock.py
@@ -1,0 +1,438 @@
+"""Exclusive per-tree lock for mutation-testing sweeps (BLUA-11 Board ruling, ADR-046 §4).
+
+A mutation sweep edits source files in place and restores them. Two sweeps against the same
+tree interleave their mutations and restores, and the damage is silent: in the BLUA-8 audit
+(F-2) a second, orphaned harness produced *confidently wrong* verdicts — sites credited
+``GUARD-FIRED`` on the strength of failures in tests that never touch the mutated module, and a
+"pristine" copy snapshotted while a guard was already neutralised, then verified against itself.
+Every contaminated site reported ``restore_green=True``. Nothing inside either sweep's own
+output could reveal it.
+
+What this module provides, and the three properties the ruling asks for:
+
+1. **Exclusivity scoped to the tree under mutation, not to the harness.** The lock file is
+   keyed on the resolved path of the tree, so a sweep on one checkout never blocks a sweep on
+   another. Acquisition is an ``O_EXCL`` create: exactly one process wins.
+
+2. **Holder liveness recorded in the lock.** The payload carries run id, pid, hostname and the
+   holder process's start time. A lock left behind by a crashed sweep is therefore
+   *identifiable as dead*, rather than indistinguishable from a live one. Without this, the two
+   recorded mid-sweep crashes (F-0, F-3) would wedge every later audit behind a manual file
+   deletion — which is exactly the undocumented improvised step that produced F-3.
+
+3. **A stale lock is a tree-integrity incident, not a file to delete.** A cooperative lock
+   stops a second sweep from *starting*; it does not stop an orphaned mutator that is already
+   past its check — F-2's second harness outlived the run that started it. So finding a stale
+   lock means the tree may carry a stranded mutation, and clearing it goes through
+   :func:`clear_stale`, which refuses without a recorded version-control verification and
+   writes an incident record before the file is removed. The procedure is in
+   ``scripts/mutation_tree_lock.md``.
+
+Both refusal paths refuse. The distinction between them is about what the operator must do
+next, and it is the reason ``LockHeld`` and ``StaleLockIncident`` are separate types rather
+than one error with a flag.
+
+**Threat-model note.** A sweep must never mutate the lock's own implementation, or the guard
+could be neutralised by the thing it is guarding. Callers should assert their mutation target
+list excludes this file; the BLUA-8 harness does so before acquiring.
+"""
+
+from __future__ import annotations
+
+import getpass
+import hashlib
+import json
+import os
+import socket
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Literal
+
+DEFAULT_LOCK_ROOT = Path.home() / ".paperclip" / "qa-audits" / ".tree-locks"
+"""Locks live outside every tree and outside ``PAPERCLIP_RUN_SCRATCH_DIR``.
+
+Run scratch is deleted at run end. F-0 lost its restore copies exactly that way; a lock stored
+there would vanish at the moment a crashed run most needs to have left a trace.
+"""
+
+Liveness = Literal["live", "dead", "unknown"]
+
+_READ_RETRIES = 5
+_READ_RETRY_SECONDS = 0.05
+
+
+@dataclass(frozen=True)
+class Holder:
+    """Who claims to hold a tree lock, and enough about them to test the claim."""
+
+    tree: str
+    run_id: str
+    pid: int
+    hostname: str
+    proc_start: str
+    user: str
+    acquired_at: str
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> Holder:
+        return cls(
+            tree=str(payload["tree"]),
+            run_id=str(payload["run_id"]),
+            pid=int(payload["pid"]),
+            hostname=str(payload["hostname"]),
+            proc_start=str(payload.get("proc_start", "")),
+            user=str(payload.get("user", "")),
+            acquired_at=str(payload.get("acquired_at", "")),
+        )
+
+
+class TreeLockError(Exception):
+    """Base for every refusal this module raises."""
+
+
+class LockHeld(TreeLockError):
+    """The tree is locked by a holder that is still running. Wait; do not intervene."""
+
+    def __init__(self, holder: Holder, lock_file: Path) -> None:
+        self.holder = holder
+        self.lock_file = lock_file
+        super().__init__(
+            f"tree {holder.tree} is locked by a LIVE sweep: run={holder.run_id} "
+            f"pid={holder.pid} on {holder.hostname} since {holder.acquired_at} "
+            f"(lock: {lock_file}). Refusing to start."
+        )
+
+
+class StaleLockIncident(TreeLockError):
+    """A lock with no live holder. This is a tree-integrity incident, not a stuck file.
+
+    Carries ``holder`` (``None`` when the lock file could not be parsed) and the liveness
+    verdict, so the incident report can state *why* the holder was judged not live.
+    """
+
+    def __init__(
+        self, holder: Holder | None, liveness: Liveness, lock_file: Path, tree: Path
+    ) -> None:
+        self.holder = holder
+        self.liveness = liveness
+        self.lock_file = lock_file
+        self.tree = tree
+        who = (
+            f"run={holder.run_id} pid={holder.pid} on {holder.hostname} since {holder.acquired_at}"
+            if holder
+            else "unreadable lock payload"
+        )
+        super().__init__(
+            f"tree {tree} carries a STALE lock ({liveness}): {who} (lock: {lock_file}). "
+            "A sweep that ended without releasing may have left a stranded mutation, and an "
+            "orphaned mutator past its own check is not stopped by this lock. Verify the tree "
+            "against version control, then clear via clear_stale(); do NOT delete the file. "
+            "See scripts/mutation_tree_lock.md."
+        )
+
+
+class NotLockOwner(TreeLockError):
+    """Refusing to release or clear a lock this process does not own."""
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat(timespec="seconds")
+
+
+def lock_file_for(tree: Path, lock_root: Path | None = None) -> Path:
+    """The lock file for one tree.
+
+    Keyed on the *resolved* tree path, so the scope is the tree under mutation and sweeps on
+    other trees stay concurrent. The basename keeps the directory name for a human reading
+    ``ls``, and a path digest for uniqueness — two checkouts of the same repo in differently
+    named parents must not collide, and two with the same name in different parents must not
+    either.
+    """
+    resolved = Path(tree).resolve()
+    digest = hashlib.sha256(str(resolved).encode("utf-8")).hexdigest()[:16]
+    root = Path(lock_root) if lock_root is not None else DEFAULT_LOCK_ROOT
+    return root / f"{resolved.name}-{digest}.lock"
+
+
+def process_start_time(pid: int) -> str | None:
+    """The start time of ``pid``, or ``None`` if no such process exists.
+
+    The pid alone is not enough: pids are recycled, so a dead sweep's pid can later belong to
+    an unrelated live process and the lock would read as live forever. Comparing the start time
+    recorded at acquisition against the start time now distinguishes "still the same process"
+    from "that number was reissued".
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    start = result.stdout.strip()
+    return start or None
+
+
+def classify(holder: Holder, *, hostname: str | None = None) -> Liveness:
+    """Is this holder still running?
+
+    ``unknown`` is deliberately not a synonym for ``dead``: a lock written on another host, or
+    one whose holder we cannot identify precisely, must not be silently reclaimed. Both
+    ``dead`` and ``unknown`` route to :class:`StaleLockIncident` — the difference is what the
+    incident report has to say.
+    """
+    here = hostname if hostname is not None else socket.gethostname()
+    if holder.hostname != here:
+        return "unknown"
+    current = process_start_time(holder.pid)
+    if current is None:
+        return "dead"
+    if not holder.proc_start:
+        # The holder's start time was never captured, so a recycled pid is indistinguishable
+        # from the original. Refuse to call it live on the pid alone.
+        return "unknown"
+    return "live" if current == holder.proc_start else "dead"
+
+
+def read_lock(lock_file: Path) -> Holder | None:
+    """Read a lock's holder, or ``None`` if the file is absent or unreadable.
+
+    A lock is created with ``O_EXCL`` and written immediately after, so a reader can catch it
+    empty in the microseconds between. Retrying separates that benign race from a genuinely
+    truncated file, which is itself an integrity signal and must survive to be reported.
+    """
+    for attempt in range(_READ_RETRIES):
+        try:
+            raw = lock_file.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return None
+        except OSError:
+            return None
+        if raw.strip():
+            try:
+                return Holder.from_payload(json.loads(raw))
+            except (ValueError, KeyError, TypeError):
+                return None
+        if attempt < _READ_RETRIES - 1:
+            time.sleep(_READ_RETRY_SECONDS)
+    return None
+
+
+def inspect(tree: Path, lock_root: Path | None = None) -> dict:
+    """State of a tree's lock, for the stale-lock procedure and for reporting.
+
+    Never mutates anything. Returns ``state`` of ``unlocked`` / ``live`` / ``stale``.
+    """
+    lock_file = lock_file_for(tree, lock_root)
+    if not lock_file.exists():
+        return {"state": "unlocked", "lock_file": str(lock_file), "holder": None, "liveness": None}
+    holder = read_lock(lock_file)
+    if holder is None:
+        return {
+            "state": "stale",
+            "lock_file": str(lock_file),
+            "holder": None,
+            "liveness": "unknown",
+            "reason": "unreadable lock payload",
+        }
+    liveness = classify(holder)
+    return {
+        "state": "live" if liveness == "live" else "stale",
+        "lock_file": str(lock_file),
+        "holder": asdict(holder),
+        "liveness": liveness,
+    }
+
+
+class TreeLock:
+    """An exclusive lock on one tree for the duration of a mutation sweep.
+
+    Use as a context manager. ``acquire`` either returns the holder record it wrote, or raises:
+    :class:`LockHeld` when a live sweep owns the tree, :class:`StaleLockIncident` when a lock
+    exists with no live holder. It never takes a lock away from anyone.
+    """
+
+    def __init__(
+        self,
+        tree: Path,
+        run_id: str,
+        *,
+        lock_root: Path | None = None,
+        pid: int | None = None,
+        hostname: str | None = None,
+    ) -> None:
+        self.tree = Path(tree).resolve()
+        self.run_id = run_id
+        self.lock_root = Path(lock_root) if lock_root is not None else DEFAULT_LOCK_ROOT
+        self.lock_file = lock_file_for(self.tree, self.lock_root)
+        self.pid = pid if pid is not None else os.getpid()
+        self.hostname = hostname if hostname is not None else socket.gethostname()
+        self.holder: Holder | None = None
+
+    def _payload(self) -> Holder:
+        try:
+            user = getpass.getuser()
+        except (KeyError, OSError):
+            user = ""
+        return Holder(
+            tree=str(self.tree),
+            run_id=self.run_id,
+            pid=self.pid,
+            hostname=self.hostname,
+            proc_start=process_start_time(self.pid) or "",
+            user=user,
+            acquired_at=_now(),
+        )
+
+    def acquire(self) -> Holder:
+        """Take the lock, or refuse. Never steals, never deletes."""
+        self.lock_root.mkdir(parents=True, exist_ok=True)
+        holder = self._payload()
+        try:
+            fd = os.open(self.lock_file, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except FileExistsError:
+            existing = read_lock(self.lock_file)
+            if existing is None:
+                raise StaleLockIncident(None, "unknown", self.lock_file, self.tree) from None
+            liveness = classify(existing, hostname=self.hostname)
+            if liveness == "live":
+                raise LockHeld(existing, self.lock_file) from None
+            raise StaleLockIncident(existing, liveness, self.lock_file, self.tree) from None
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(asdict(holder), fh, indent=2, sort_keys=True)
+            fh.write("\n")
+            fh.flush()
+            os.fsync(fh.fileno())
+        self.holder = holder
+        return holder
+
+    def release(self) -> None:
+        """Release a lock this process owns. Refuses to remove anyone else's."""
+        current = read_lock(self.lock_file)
+        if current is None:
+            self.holder = None
+            return
+        if current.run_id != self.run_id or current.pid != self.pid:
+            raise NotLockOwner(
+                f"refusing to release {self.lock_file}: held by run={current.run_id} "
+                f"pid={current.pid}, this process is run={self.run_id} pid={self.pid}"
+            )
+        self.lock_file.unlink(missing_ok=True)
+        self.holder = None
+
+    def __enter__(self) -> Holder:
+        return self.acquire()
+
+    def __exit__(self, exc_type, exc, tb) -> Literal[False]:
+        self.release()
+        return False
+
+
+def clear_stale(
+    tree: Path,
+    *,
+    verified_against: str,
+    cleared_by: str,
+    note: str = "",
+    lock_root: Path | None = None,
+) -> dict:
+    """Close out a stale lock as a tree-integrity incident, then remove the lock file.
+
+    ``verified_against`` is the version-control reference the tree was checked against before
+    this call — the whole point of the ruling is that the tree is verified *before* the next
+    sweep starts, so a call with nothing to record is refused rather than accepted with a blank
+    field. The incident is appended to ``incidents.jsonl`` before the file is unlinked, so a
+    crash between the two leaves the record, not the silence.
+
+    Refuses outright if the holder is live: clearing is not a way to evict a running sweep.
+    """
+    if not verified_against.strip():
+        raise TreeLockError(
+            "clear_stale requires verified_against: the version-control reference the tree was "
+            "verified against before the next sweep. A stale lock means a sweep ended without "
+            "releasing and may have left a stranded mutation; deleting the file without that "
+            "check is the improvised step this procedure exists to replace."
+        )
+    if not cleared_by.strip():
+        raise TreeLockError(
+            "clear_stale requires cleared_by: a gate with no named clearer is not reviewed."
+        )
+
+    lock_file = lock_file_for(tree, lock_root)
+    if not lock_file.exists():
+        raise TreeLockError(f"no lock to clear at {lock_file}")
+
+    holder = read_lock(lock_file)
+    liveness: Liveness = "unknown" if holder is None else classify(holder)
+    if liveness == "live":
+        assert holder is not None
+        raise LockHeld(holder, lock_file)
+
+    record = {
+        "kind": "stale-lock-incident",
+        "recorded_at": _now(),
+        "tree": str(Path(tree).resolve()),
+        "lock_file": str(lock_file),
+        "holder": asdict(holder) if holder else None,
+        "liveness": liveness,
+        "verified_against": verified_against,
+        "cleared_by": cleared_by,
+        "note": note,
+    }
+    root = lock_file.parent
+    root.mkdir(parents=True, exist_ok=True)
+    incidents = root / "incidents.jsonl"
+    with incidents.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, sort_keys=True) + "\n")
+        fh.flush()
+        os.fsync(fh.fileno())
+    lock_file.unlink()
+    record["incidents_log"] = str(incidents)
+    return record
+
+
+def _main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description="Inspect or clear a mutation-sweep tree lock.")
+    ap.add_argument("command", choices=["inspect", "clear"])
+    ap.add_argument("--tree", required=True)
+    ap.add_argument("--lock-root", default=None)
+    ap.add_argument("--verified-against", default="", help="VCS ref the tree was verified against")
+    ap.add_argument("--cleared-by", default="", help="named clearer")
+    ap.add_argument("--note", default="")
+    a = ap.parse_args(argv)
+
+    root = Path(a.lock_root) if a.lock_root else None
+    if a.command == "inspect":
+        print(json.dumps(inspect(Path(a.tree), root), indent=2, sort_keys=True))
+        return 0
+    try:
+        print(
+            json.dumps(
+                clear_stale(
+                    Path(a.tree),
+                    verified_against=a.verified_against,
+                    cleared_by=a.cleared_by,
+                    note=a.note,
+                    lock_root=root,
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    except TreeLockError as exc:
+        print(f"REFUSED: {exc}")
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/tests/test_mutation_tree_lock.py
+++ b/tests/test_mutation_tree_lock.py
@@ -1,0 +1,445 @@
+"""The mutation-sweep tree lock must be observed refusing things (BLUA-11 / ADR-046 §4).
+
+The lock is a guard, so it is subject to the rule it exists to serve: a passing check counts
+only if it could have failed. A lock never observed refusing anything is not evidence that it
+locks — and the failure mode it was ruled in to prevent (F-2) was one where every check in the
+sweep reported green while the results were wrong.
+
+So the refusals here are driven by *real* holders in *real* subprocesses, not by a stubbed
+liveness probe:
+
+* a live holder is a process that is genuinely running and has genuinely taken the lock;
+* a dead holder is that same process ``SIGKILL``-ed mid-hold, which is the shape of the two
+  recorded mid-sweep crashes (F-0, F-3) — it cannot release, so it leaves the lock behind.
+
+Every refusal test is paired with a control showing the same call path succeeds when the
+condition is absent. Without the control, a lock that refused unconditionally would pass the
+refusal tests, and "it refused" would carry no information.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+import time
+
+import pytest
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+MODULE_PATH = REPO / "scripts" / "mutation_tree_lock.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("mutation_tree_lock", MODULE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec: dataclasses resolve their own __module__ at class-creation time.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+tl = _load()
+
+
+# --------------------------------------------------------------------------------------
+# A real holder in a real process.
+# --------------------------------------------------------------------------------------
+
+_HOLDER_SOURCE = """
+import importlib.util, sys, time
+spec = importlib.util.spec_from_file_location("mutation_tree_lock", {module!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+lock = m.TreeLock({tree!r}, {run_id!r}, lock_root={root!r})
+lock.acquire()
+print("ACQUIRED", flush=True)
+time.sleep(600)
+"""
+
+
+class _Holder:
+    """A subprocess that really holds the lock until it is killed or terminated."""
+
+    def __init__(self, tree, lock_root, run_id="holder-run"):
+        source = _HOLDER_SOURCE.format(
+            module=str(MODULE_PATH), tree=str(tree), run_id=run_id, root=str(lock_root)
+        )
+        self.proc = subprocess.Popen(
+            [sys.executable, "-c", source], stdout=subprocess.PIPE, text=True
+        )
+        assert self.proc.stdout is not None
+        line = self.proc.stdout.readline().strip()
+        assert line == "ACQUIRED", f"holder failed to take the lock: {line!r}"
+
+    @property
+    def pid(self) -> int:
+        return self.proc.pid
+
+    def kill_without_releasing(self) -> None:
+        """SIGKILL: the holder cannot run cleanup, so the lock file survives it."""
+        self.proc.send_signal(signal.SIGKILL)
+        self.proc.wait(timeout=10)
+        # The pid must actually be gone before liveness is judged, or "dead" would be a race.
+        for _ in range(100):
+            if tl.process_start_time(self.proc.pid) is None:
+                return
+            time.sleep(0.02)
+        pytest.fail(f"holder pid {self.proc.pid} still resolvable after SIGKILL")
+
+    def stop(self) -> None:
+        if self.proc.poll() is None:
+            self.proc.kill()
+            self.proc.wait(timeout=10)
+
+
+@pytest.fixture
+def tree(tmp_path):
+    d = tmp_path / "checkout-a"
+    d.mkdir()
+    return d
+
+
+@pytest.fixture
+def lock_root(tmp_path):
+    return tmp_path / "locks"
+
+
+# --------------------------------------------------------------------------------------
+# 1. Exclusivity, and that it is scoped to the tree rather than to the harness.
+# --------------------------------------------------------------------------------------
+
+
+def test_a_second_sweep_against_a_live_held_tree_is_refused(tree, lock_root):
+    """(a) of the falsifiability requirement, demonstrated against a genuinely live holder."""
+    holder = _Holder(tree, lock_root)
+    try:
+        with pytest.raises(tl.LockHeld) as caught:
+            tl.TreeLock(tree, "second-run", lock_root=lock_root).acquire()
+    finally:
+        holder.stop()
+
+    assert caught.value.holder.pid == holder.pid
+    assert caught.value.holder.run_id == "holder-run"
+    assert "LIVE" in str(caught.value)
+
+
+def test_the_same_call_succeeds_once_the_holder_is_gone(tree, lock_root):
+    """Control for the test above: the refusal is conditional on a live holder, not blanket.
+
+    A lock that refused every acquisition would pass the refusal test and be useless. This is
+    what makes that test's pass informative.
+    """
+    holder = _Holder(tree, lock_root)
+    with pytest.raises(tl.LockHeld):
+        tl.TreeLock(tree, "second-run", lock_root=lock_root).acquire()
+
+    holder.proc.terminate()
+    holder.proc.wait(timeout=10)
+    # The killed holder leaves its file behind; clear it as the procedure requires.
+    tl.clear_stale(tree, verified_against="test-fixture", cleared_by="test", lock_root=lock_root)
+
+    got = tl.TreeLock(tree, "second-run", lock_root=lock_root).acquire()
+    assert got.run_id == "second-run"
+
+
+def test_a_sweep_on_another_tree_is_not_blocked(tree, tmp_path, lock_root):
+    """The ruling is a per-tree lock, not a global harness lock.
+
+    This fails against a single shared lock file, which is the obvious wrong implementation.
+    """
+    other = tmp_path / "checkout-b"
+    other.mkdir()
+
+    holder = _Holder(tree, lock_root)
+    try:
+        got = tl.TreeLock(other, "other-tree-run", lock_root=lock_root).acquire()
+        assert got.tree == str(other.resolve())
+        assert tl.lock_file_for(tree, lock_root) != tl.lock_file_for(other, lock_root)
+    finally:
+        holder.stop()
+
+
+def test_two_checkouts_with_the_same_directory_name_get_different_locks(tmp_path, lock_root):
+    a = tmp_path / "one" / "repo"
+    b = tmp_path / "two" / "repo"
+    a.mkdir(parents=True)
+    b.mkdir(parents=True)
+    assert tl.lock_file_for(a, lock_root) != tl.lock_file_for(b, lock_root)
+
+
+def test_only_one_of_many_racing_acquirers_wins(tree, lock_root):
+    """Exclusivity under an actual race, not merely under sequential calls."""
+    source = f"""
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("mutation_tree_lock", {str(MODULE_PATH)!r})
+m = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = m
+spec.loader.exec_module(m)
+try:
+    m.TreeLock({str(tree)!r}, sys.argv[1], lock_root={str(lock_root)!r}).acquire()
+    print("WON")
+except m.TreeLockError:
+    print("REFUSED")
+"""
+
+    procs = [
+        subprocess.Popen(
+            [sys.executable, "-c", source, f"racer-{i}"], stdout=subprocess.PIPE, text=True
+        )
+        for i in range(8)
+    ]
+    outs = [p.communicate(timeout=60)[0].strip() for p in procs]
+    assert outs.count("WON") == 1, outs
+
+
+# --------------------------------------------------------------------------------------
+# 2. Liveness: a dead holder is identifiable as dead.
+# --------------------------------------------------------------------------------------
+
+
+def test_a_lock_left_by_a_crashed_sweep_is_stale_not_live(tree, lock_root):
+    """(b) of the falsifiability requirement.
+
+    Same tree, same acquire call, same lock file as the live case above — the only thing that
+    changed is whether the holder is still running, and the outcome is a different exception
+    type. That is the distinction the ruling asks the lock to make: without it, F-0 and F-3
+    would each have wedged every later audit behind a manual file deletion.
+    """
+    holder = _Holder(tree, lock_root)
+    holder.kill_without_releasing()
+
+    with pytest.raises(tl.StaleLockIncident) as caught:
+        tl.TreeLock(tree, "next-run", lock_root=lock_root).acquire()
+
+    assert caught.value.liveness == "dead"
+    assert caught.value.holder is not None
+    assert caught.value.holder.pid == holder.pid
+    assert tl.inspect(tree, lock_root)["state"] == "stale"
+
+
+def test_live_and_stale_are_different_verdicts_not_one_refusal(tree, lock_root):
+    """The two refusals must not collapse into a single 'locked' error.
+
+    They demand opposite responses: wait, versus verify the tree against version control. A
+    lock that raised one type for both would pass every other test in this file.
+    """
+    holder = _Holder(tree, lock_root)
+    live_state = tl.inspect(tree, lock_root)
+    with pytest.raises(tl.LockHeld):
+        tl.TreeLock(tree, "x", lock_root=lock_root).acquire()
+
+    holder.kill_without_releasing()
+    dead_state = tl.inspect(tree, lock_root)
+    with pytest.raises(tl.StaleLockIncident):
+        tl.TreeLock(tree, "x", lock_root=lock_root).acquire()
+
+    assert live_state["state"] == "live" and live_state["liveness"] == "live"
+    assert dead_state["state"] == "stale" and dead_state["liveness"] == "dead"
+    assert live_state["holder"] == dead_state["holder"], (
+        "the payload did not change; only the holder's liveness did"
+    )
+    assert not issubclass(tl.LockHeld, tl.StaleLockIncident)
+    assert not issubclass(tl.StaleLockIncident, tl.LockHeld)
+
+
+def test_a_recycled_pid_does_not_read_as_live(tree, lock_root):
+    """Liveness is pid *and* process start time.
+
+    A pid-only check — ``os.kill(pid, 0)`` — reports live as soon as the number is reissued to
+    any unrelated process, and the stale lock then never expires. Here the recorded start time
+    is wrong while the pid is this very test process, so it is unambiguously alive: a pid-only
+    implementation returns "live" and this assertion fails.
+    """
+    holder = tl.Holder(
+        tree=str(tree),
+        run_id="ghost",
+        pid=os.getpid(),
+        hostname=tl.socket.gethostname(),
+        proc_start="Thu Jan  1 00:00:00 1970",
+        user="",
+        acquired_at="1970-01-01T00:00:00+00:00",
+    )
+    assert tl.process_start_time(os.getpid()) is not None, "this process must be alive"
+    assert tl.classify(holder) == "dead"
+
+
+def test_a_holder_on_another_host_is_unknown_not_live(tree, lock_root):
+    holder = tl.Holder(
+        tree=str(tree),
+        run_id="elsewhere",
+        pid=os.getpid(),
+        hostname="some-other-machine",
+        proc_start="whenever",
+        user="",
+        acquired_at="1970-01-01T00:00:00+00:00",
+    )
+    assert tl.classify(holder) == "unknown"
+
+
+def test_a_holder_with_no_recorded_start_time_is_unknown_not_live(tree, lock_root):
+    """Refusing to judge on the pid alone when the start time was never captured."""
+    holder = tl.Holder(
+        tree=str(tree),
+        run_id="partial",
+        pid=os.getpid(),
+        hostname=tl.socket.gethostname(),
+        proc_start="",
+        user="",
+        acquired_at="1970-01-01T00:00:00+00:00",
+    )
+    assert tl.classify(holder) == "unknown"
+
+
+def test_an_unreadable_lock_is_an_incident_not_a_silent_overwrite(tree, lock_root):
+    """A truncated lock is itself an integrity signal and must not be treated as absent."""
+    lock_file = tl.lock_file_for(tree, lock_root)
+    lock_file.parent.mkdir(parents=True, exist_ok=True)
+    lock_file.write_text("{ this is not json", encoding="utf-8")
+
+    with pytest.raises(tl.StaleLockIncident) as caught:
+        tl.TreeLock(tree, "next-run", lock_root=lock_root).acquire()
+    assert caught.value.holder is None
+    assert caught.value.liveness == "unknown"
+    assert lock_file.exists()
+
+
+# --------------------------------------------------------------------------------------
+# 3. A stale lock is a tree-integrity incident, not a file to delete.
+# --------------------------------------------------------------------------------------
+
+
+def test_refusing_a_stale_lock_does_not_remove_it(tree, lock_root):
+    """The refusal must leave the evidence in place for the incident procedure."""
+    holder = _Holder(tree, lock_root)
+    holder.kill_without_releasing()
+    lock_file = tl.lock_file_for(tree, lock_root)
+
+    with pytest.raises(tl.StaleLockIncident):
+        tl.TreeLock(tree, "next-run", lock_root=lock_root).acquire()
+    assert lock_file.exists(), "a stale lock is not self-clearing"
+
+    with pytest.raises(tl.StaleLockIncident):
+        tl.TreeLock(tree, "next-run", lock_root=lock_root).acquire()
+    assert lock_file.exists()
+
+
+def test_clearing_without_a_version_control_verification_is_refused(tree, lock_root):
+    """The tree must be verified against version control *before* the next sweep starts.
+
+    F-3 was produced by exactly the improvised step this refuses: deleting the leftover and
+    carrying on.
+    """
+    holder = _Holder(tree, lock_root)
+    holder.kill_without_releasing()
+    lock_file = tl.lock_file_for(tree, lock_root)
+
+    with pytest.raises(tl.TreeLockError, match="verified_against"):
+        tl.clear_stale(tree, verified_against="   ", cleared_by="qa-lead", lock_root=lock_root)
+    assert lock_file.exists()
+
+
+def test_clearing_without_a_named_clearer_is_refused(tree, lock_root):
+    holder = _Holder(tree, lock_root)
+    holder.kill_without_releasing()
+    lock_file = tl.lock_file_for(tree, lock_root)
+
+    with pytest.raises(tl.TreeLockError, match="cleared_by"):
+        tl.clear_stale(tree, verified_against="49b472c", cleared_by="", lock_root=lock_root)
+    assert lock_file.exists()
+
+
+def test_clearing_records_the_incident_before_removing_the_lock(tree, lock_root):
+    """Control for the two refusals above, and the durable-record requirement."""
+    holder = _Holder(tree, lock_root)
+    holder.kill_without_releasing()
+    lock_file = tl.lock_file_for(tree, lock_root)
+
+    record = tl.clear_stale(
+        tree,
+        verified_against="49b472c",
+        cleared_by="qa-lead",
+        note="stranded mutation check",
+        lock_root=lock_root,
+    )
+    assert not lock_file.exists()
+
+    written = [
+        json.loads(line)
+        for line in (lock_root / "incidents.jsonl").read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(written) == 1
+    assert written[0]["verified_against"] == "49b472c"
+    assert written[0]["cleared_by"] == "qa-lead"
+    assert written[0]["liveness"] == "dead"
+    assert written[0]["holder"]["pid"] == holder.pid
+    assert record["kind"] == "stale-lock-incident"
+
+    # And the tree is now acquirable, so the procedure actually unblocks the next sweep.
+    assert tl.TreeLock(tree, "next-run", lock_root=lock_root).acquire().run_id == "next-run"
+
+
+def test_clearing_a_live_lock_is_refused(tree, lock_root):
+    """Clearing is not an eviction route for a running sweep."""
+    holder = _Holder(tree, lock_root)
+    try:
+        with pytest.raises(tl.LockHeld):
+            tl.clear_stale(
+                tree, verified_against="49b472c", cleared_by="qa-lead", lock_root=lock_root
+            )
+        assert tl.lock_file_for(tree, lock_root).exists()
+    finally:
+        holder.stop()
+
+
+# --------------------------------------------------------------------------------------
+# 4. Release.
+# --------------------------------------------------------------------------------------
+
+
+def test_release_refuses_to_remove_another_holders_lock(tree, lock_root):
+    holder = _Holder(tree, lock_root)
+    try:
+        impostor = tl.TreeLock(tree, "not-mine", lock_root=lock_root)
+        with pytest.raises(tl.NotLockOwner):
+            impostor.release()
+        assert tl.lock_file_for(tree, lock_root).exists()
+    finally:
+        holder.stop()
+
+
+def test_the_context_manager_releases_on_the_way_out(tree, lock_root):
+    lock_file = tl.lock_file_for(tree, lock_root)
+    with tl.TreeLock(tree, "run-1", lock_root=lock_root) as held:
+        assert lock_file.exists()
+        assert held.run_id == "run-1"
+    assert not lock_file.exists()
+    tl.TreeLock(tree, "run-2", lock_root=lock_root).acquire()
+
+
+def test_the_context_manager_releases_when_the_sweep_raises(tree, lock_root):
+    """A crashing sweep inside the block must not leave the tree locked."""
+    lock_file = tl.lock_file_for(tree, lock_root)
+    with pytest.raises(RuntimeError):
+        with tl.TreeLock(tree, "run-1", lock_root=lock_root):
+            raise RuntimeError("sweep blew up")
+    assert not lock_file.exists()
+
+
+def test_locks_are_not_stored_in_run_scratch(tree):
+    """F-0 lost its restore copies to ``PAPERCLIP_RUN_SCRATCH_DIR``, which Paperclip deletes.
+
+    A lock kept there would vanish at exactly the moment a crashed run most needs to have left
+    a trace, and the crash would be indistinguishable from a clean exit.
+    """
+    default = str(tl.DEFAULT_LOCK_ROOT)
+    assert "scratch" not in default.lower()
+    assert not default.startswith("/tmp")
+    assert str(pathlib.Path(tl.lock_file_for(tree)).parent) == default


### PR DESCRIPTION
Implements the exclusive tree lock ruled in at ADR-046 §4, effective at the next sweep. This is the implementation, not a re-opening of the decision.

## Why

Two of the four deviations recorded in the guard falsifiability audit share one root cause: an unsynchronised mutator on a shared working tree. It did not fail loudly — it produced *confidently wrong* results. Sites were credited `GUARD-FIRED` on the strength of failures in tests that never touch the mutated module, and the competing harness snapshotted its "pristine" copy while a guard was already neutralised, then verified each restore by comparing that copy against itself. Every contaminated site reported `restore_green=True`. Nothing in either sweep's own output could reveal it.

## What the lock does

1. **Exclusive, scoped to the tree under mutation** — keyed on the resolved tree path, so sweeps on other checkouts stay concurrent. Acquisition is an `O_EXCL` create.
2. **Records holder liveness** — run id, pid, hostname, and the holder process's start time. A lock left by a crashed sweep is therefore identifiable as *dead*. The pid alone is not enough: pids are recycled, and a pid-only check reports live as soon as the number is reissued, so the lock would never expire and every later audit would be wedged behind a manual file deletion — the improvised step that produced one of the recorded deviations.
3. **A stale lock is a tree-integrity incident, not a file to delete** — a cooperative lock stops a second sweep from *starting*; it does not stop an orphaned mutator already past its own check. Clearing goes through `clear_stale()`, which refuses without a version-control reference and a named clearer, and appends the incident record *before* unlinking. The procedure is in `scripts/mutation_tree_lock.md`.

`LockHeld` and `StaleLockIncident` are separate types because they demand opposite responses: wait, versus verify the tree against version control.

Locks live outside every tree and outside the run scratch directory, which is deleted at run end — a lock stored there would vanish at exactly the moment a crashed run most needs to have left a trace.

## Evidence that it can fail

The lock is a guard, so the falsifiability rule applies to it. Refusals are demonstrated against **real holders in real subprocesses** — a live holder that is genuinely running and holding, and that same process `SIGKILL`-ed mid-hold (the shape of the recorded mid-sweep crashes). Every refusal test is paired with a control showing the same call path succeeds when the condition is absent; without it, a lock that refused unconditionally would pass every refusal test.

Seven mutations, each neutralising one claimed property, run against the suite:

| Mutation | Property neutralised | Result |
|---|---|---|
| global lock file, not per-tree | scoped to the tree under mutation | ON-TARGET, 2/2 attributed |
| pid-only liveness | a recycled pid does not read as live | ON-TARGET, 2/2 |
| stale collapsed into held | live and stale are different verdicts | ON-TARGET, 2/2 |
| stale silently reclaimed | a stale lock is an incident, not a deletion | ON-TARGET, 2/2 |
| VCS-verification requirement removed | clearing requires a verification on record | ON-TARGET, 1/1 |
| `O_EXCL` dropped | acquisition is exclusive | ON-TARGET, 2/2 |
| `clear_stale` evicts a live holder | clearing is not an eviction route | ON-TARGET, 1/1 |

**7/7 ON-TARGET** — suite red *and* the failures attributed to the tests asserting that property, not merely red. Every restore was from a file-system copy (never version control), and every re-run returned green. The module was verified byte-identical to the copy afterwards.

Suite: **869 passed, 2 skipped**. `ruff check`, `ruff format`, `pyright` clean.

Wiring was also verified end-to-end against the real harness: a sweep against a live-held tree exits 2, against the stale lock that holder left exits 3, the lock file is not removed by either refusal, and `git diff src/` is empty — the refusal happens before any mutation is applied.

## Scope limits, stated rather than implied

- **The lock cannot protect the lock.** The sweep of this module ran single-process and sequential, asserting the tree byte-identical to the copy around each mutation instead.
- **Cooperative only.** A process not going through `TreeLock` is unaffected; the lock makes a concurrent sweep detectable and refused *at start*, not impossible.
- **One host.** A lock from another hostname classifies `unknown` and refuses; cross-host sweeps on a shared filesystem are out of scope.

The attribution check (a failing test must name the mutated guard, not merely turn the suite red) remains a standing requirement independently of this change; the lock does not replace it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)